### PR TITLE
Improve backend test infrastructure and add CI gating

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -12,7 +12,6 @@ paths: ["backend/**"]
 - Categories are kebab-case, lowercase, English-only — normalized on storage.
 - REST naming: nouns in URLs, HTTP methods as verbs. Action endpoints use POST with a noun (`POST /downloads` not `POST /pull`). Singleton resources skip IDs (`/api/preferences`, `/api/ollama/downloads`).
 - Don't mix CRUD with actions — saving config and triggering rescore are separate endpoints, not one overloaded call.
-- FastAPI `dependency_overrides` keys by function object — tests must import `get_session` from the same module as routers (`deps.py`).
 
 ## SQLAlchemy / SQLite
 
@@ -34,3 +33,13 @@ paths: ["backend/**"]
 - Config priority: env vars > `.env` file > YAML config (`CONFIG_FILE`) > defaults in `config.py`.
 - Nested env vars use double-underscore notation (e.g., `OLLAMA__HOST`).
 - Settings cached via `@lru_cache` — requires restart to pick up changes.
+
+## Testing
+
+- FastAPI `dependency_overrides` keys by function object — tests must import `get_session` from the same module as routers (`deps.py`).
+- Use `test_session.expire_all()` after API writes to see fresh DB state in test assertions.
+- Use `@pytest.mark.asyncio` only on `async def` test functions — not on sync functions using TestClient.
+- Don't mock database calls — use real SQLite test databases via fixtures.
+- Don't use `:memory:` SQLite without `StaticPool` — tables are invisible across connections without it.
+- Factory fixtures (`make_feed`, `make_article`, `make_category`) go in `conftest.py` — per-file helpers only when no factory covers the need.
+- Patch lifespan side-effects in `test_client` fixture — don't let TestClient hit production DB or start scheduler.

--- a/.claude/skills/backend-testing/SKILL.md
+++ b/.claude/skills/backend-testing/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: backend-testing
+description: "Backend testing patterns — fixture hierarchy, dependency overrides, factory helpers, monkeypatch vs respx, pure function testing, and migration tests"
+---
+
+# Backend Testing
+
+Rules: `.claude/rules/backend.md` → Testing section
+
+## Key Patterns
+
+### 1. Fixture Hierarchy (`conftest.py`)
+
+Three fixtures form the core chain: `test_engine` → `test_session` → `test_client`.
+
+```python
+@pytest.fixture(name="test_engine")
+def test_engine_fixture():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+    yield engine
+    engine.dispose()
+```
+
+`StaticPool` forces SQLAlchemy to reuse the same connection for every checkout. Without it, each `Session(engine)` call would open a new connection to `:memory:`, which creates an entirely separate database -- tables created in one connection are invisible to another.
+
+```python
+@pytest.fixture(name="test_session")
+def test_session_fixture(test_engine):
+    with Session(test_engine) as session:
+        yield session
+```
+
+`test_session` is used for direct DB setup/assertions in tests. `test_client` creates its own sessions via the dependency override (see below).
+
+### 2. Lifespan Handling
+
+`test_client` patches four lifespan side-effects to no-ops BEFORE entering `TestClient(app)`:
+
+```python
+@pytest.fixture(name="test_client")
+def test_client_fixture(test_engine, monkeypatch):
+    monkeypatch.setattr("backend.main.create_db_and_tables", lambda: None)
+    monkeypatch.setattr("backend.main.start_scheduler", lambda: None)
+    monkeypatch.setattr("backend.main.shutdown_scheduler", lambda: None)
+
+    async def _noop_close():
+        pass
+
+    monkeypatch.setattr("backend.main.close_ollama_client", _noop_close)
+
+    def get_test_session():
+        with Session(test_engine) as session:
+            yield session
+
+    app.dependency_overrides[get_session] = get_test_session
+
+    with TestClient(app) as client:
+        yield client
+
+    app.dependency_overrides.clear()
+```
+
+Why: without these patches, `TestClient(app)` triggers the real lifespan, which would create the production database, start APScheduler cron jobs, and initialize the Ollama client.
+
+The dependency override replaces `get_session` (imported from `backend.deps`) so every API route gets a session backed by the in-memory test engine instead of the production one.
+
+### 3. Factory Fixtures
+
+`make_feed`, `make_article`, and `make_category` each return a callable with sensible defaults and auto-incrementing counters for unique URLs/slugs:
+
+```python
+@pytest.fixture(name="make_feed")
+def make_feed_fixture(test_session: Session):
+    _counter = 0
+
+    def _make(**overrides) -> Feed:
+        nonlocal _counter
+        _counter += 1
+        defaults = {
+            "url": f"https://example.com/feed-{_counter}.xml",
+            "title": f"Test Feed {_counter}",
+            "last_fetched_at": datetime.now(),
+        }
+        defaults.update(overrides)
+        feed = Feed(**defaults)
+        test_session.add(feed)
+        test_session.commit()
+        test_session.refresh(feed)
+        return feed
+
+    return _make
+```
+
+Usage:
+
+```python
+def test_something(make_feed, make_article):
+    feed = make_feed(title="Custom Feed")
+    article = make_article(feed_id=feed.id, is_read=True)
+```
+
+`make_article` requires `feed_id` as the first positional argument. `make_feed` and `make_category` take only keyword overrides.
+
+### 4. Session Cache Invalidation
+
+`test_client` creates its own sessions via the dependency override. When a test writes via the API and then reads via `test_session`, the session has stale cached objects:
+
+```python
+def test_mark_article_read(test_client, sample_articles, test_session):
+    article_id = sample_articles[0].id
+    test_client.patch(f"/api/articles/{article_id}", json={"is_read": True})
+
+    # WRONG: test_session still has the old cached object
+    # db_article = test_session.get(Article, article_id)
+
+    # RIGHT: expire the cache first
+    db_article = test_session.get(Article, article_id)
+    test_session.refresh(db_article)  # single object
+    assert db_article.is_read is True
+```
+
+Use `test_session.expire_all()` to invalidate everything, or `test_session.refresh(obj)` for a single object.
+
+### 5. Mocking External Dependencies
+
+Two patterns depending on what layer you're testing:
+
+**`monkeypatch.setattr`** -- replaces an entire function. Good for testing business logic above the fetch layer:
+
+```python
+def test_create_feed(test_client, monkeypatch):
+    async def fake_fetch_feed(_url: str):
+        return _ParsedFeed()
+
+    def fake_save_articles(_session, _feed_id, _entries):
+        return (1, [])
+
+    monkeypatch.setattr("backend.routers.feeds.fetch_feed", fake_fetch_feed)
+    monkeypatch.setattr("backend.routers.feeds.save_articles", fake_save_articles)
+
+    response = test_client.post("/api/feeds", json={"url": "https://example.com/feed.xml"})
+    assert response.status_code == 201
+```
+
+The patch path must reference the module where the function is **used** (e.g. `backend.routers.feeds.fetch_feed`), not where it's defined.
+
+**`respx`** -- intercepts at the httpx transport layer. Good for testing `fetch_feed` itself (error codes, timeouts, malformed responses). The `respx` library is installed but no shared fixture exists yet. Use it directly:
+
+```python
+import respx
+
+@respx.mock
+def test_fetch_feed_timeout():
+    respx.get("https://example.com/feed.xml").mock(side_effect=httpx.ReadTimeout(""))
+    # call fetch_feed and assert it handles the timeout
+```
+
+### 6. Async Test Pattern
+
+Use `@pytest.mark.asyncio` only on `async def` test functions that directly `await` something:
+
+```python
+@pytest.mark.asyncio
+async def test_evaluate_task_readiness_model_missing(test_session, monkeypatch):
+    # ... setup ...
+    runtime = await evaluate_task_readiness(test_session, TASK_CATEGORIZATION)
+    assert runtime.ready is False
+```
+
+NOT needed for tests using `TestClient` -- it's synchronous even when calling async endpoints:
+
+```python
+# No @pytest.mark.asyncio needed here
+def test_list_articles(test_client):
+    response = test_client.get("/api/articles")
+    assert response.status_code == 200
+```
+
+`asyncio_mode = "strict"` is configured in `pyproject.toml`, so unmarked async tests will error rather than silently run.
+
+### 7. Pure Function Testing
+
+The `test_scoring.py` pattern: construct model objects manually (no DB, no client), test pure functions directly. Use a local helper like `_make_category()` that sets relationship attributes without persistence:
+
+```python
+def _make_category(
+    weight: str | None = None,
+    is_hidden: bool = False,
+    parent: Category | None = None,
+) -> Category:
+    cat = Category(
+        id=1, display_name="test", slug="test",
+        weight=weight, is_hidden=is_hidden,
+        parent_id=parent.id if parent else None,
+    )
+    cat.parent = parent  # type: ignore[assignment]
+    return cat
+
+
+def test_effective_weight_inherits_parent():
+    parent = _make_category(weight="reduce")
+    child = _make_category(parent=parent)
+    assert get_effective_weight(child) == "reduce"
+```
+
+No fixtures needed -- objects are constructed inline and never touch the database.
+
+### 8. Migration Testing
+
+`test_migrations.py` uses raw `sqlite3.connect()` to create pre-migration schemas, then runs `alembic.command.upgrade()`:
+
+```python
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+
+def _make_alembic_config(db_path: Path) -> Config:
+    config = Config(str(BACKEND_ROOT / "alembic.ini"))
+    config.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    return config
+
+def test_upgrade_head_backfills_provider_and_routes():
+    with tempfile.NamedTemporaryFile(suffix=".db") as tmp:
+        db_path = Path(tmp.name)
+        _create_pre_feature_schema(db_path)       # raw sqlite3 DDL
+
+        cfg = _make_alembic_config(db_path)
+        command.upgrade(cfg, "head")
+
+        with sqlite3.connect(db_path) as conn:
+            # assert on migrated state with raw SQL
+```
+
+These tests use real temp files (not `:memory:`) because Alembic needs file paths for its `sqlalchemy.url` config. They don't use any conftest fixtures -- each test is fully self-contained with its own pre-migration schema and temp database.
+
+## Anti-Patterns
+
+- **Importing `get_session` from wrong module** -- must be from `backend.deps` (same function object routers use). Importing from another module creates a different function object and `dependency_overrides` won't match.
+- **`@pytest.mark.asyncio` on sync TestClient tests** -- unnecessary and misleading. `TestClient` runs an internal event loop; the test function itself is synchronous.
+- **Sharing DB state between tests** -- each test gets a fresh in-memory database via the `test_engine` fixture. Don't rely on data from another test.
+- **Mocking database calls** -- use real SQLite test databases via fixtures. Mocking `session.exec()` etc. hides real query bugs.
+- **`:memory:` SQLite without `StaticPool`** -- tables created in one connection are invisible to another. `StaticPool` forces connection reuse so the in-memory DB is shared.
+- **`asyncio_mode = "auto"`** -- keep `"strict"` so every async test requires an explicit `@pytest.mark.asyncio` mark. Auto mode hides which tests are actually async.
+
+## Decision Aids
+
+| Scenario | Use |
+|----------|-----|
+| Testing API endpoint behavior | `TestClient` + `test_client` fixture |
+| Testing async function directly | `@pytest.mark.asyncio` + `await` the function |
+| Testing pure function (no DB, no I/O) | Direct function call, construct objects manually |
+| Verifying DB state after API call | `test_session.expire_all()` then query |
+| Mocking a function the router calls | `monkeypatch.setattr("backend.routers.module.func", fake)` |
+| Mocking HTTP responses at transport layer | `respx` mock decorator or context manager |
+| Testing Alembic migrations | Raw `sqlite3` setup + `alembic.command.upgrade()` |
+| Need test data for a single test file | Per-file `_create_entity()` helper (rare) |
+| Need test data across many test files | Factory fixture in `conftest.py` (`make_feed`, etc.) |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,8 +30,34 @@ jobs:
         working-directory: frontend
         run: bun run test
 
+  test-backend:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Install dependencies
+        working-directory: backend
+        run: uv sync
+
+      - name: Lint
+        working-directory: backend
+        run: uv run ruff check .
+
+      - name: Run tests
+        working-directory: backend
+        run: uv run pytest
+
   build-and-push:
-    needs: [test]
+    needs: [test, test-backend]
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -33,6 +33,7 @@ build-backend = "uv_build"
 dev = [
     "pytest>=9.0.2",
     "pytest-asyncio>=1.3.0",
+    "respx>=0.22.0",
     "ruff>=0.15.0",
 ]
 
@@ -55,6 +56,10 @@ ignore = [
     "E501",   # line too long (handled by formatter)
     "B008",   # function call in argument defaults (FastAPI Depends pattern)
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "strict"
 
 [tool.ruff.format]
 quote-style = "double"

--- a/backend/tests/test_feed_folders_api.py
+++ b/backend/tests/test_feed_folders_api.py
@@ -1,57 +1,11 @@
 """Integration tests for feed folder endpoints and folder-aware feed/article behavior."""
 
-from datetime import datetime
+from typing import Callable
 
 from fastapi.testclient import TestClient
 from sqlmodel import Session, select
 
 from backend.models import Article, Feed, FeedFolder
-
-
-def _create_feed(
-    session: Session,
-    *,
-    title: str,
-    url: str,
-    display_order: int,
-    folder_id: int | None = None,
-) -> Feed:
-    feed = Feed(
-        title=title,
-        url=url,
-        display_order=display_order,
-        last_fetched_at=datetime.now(),
-        folder_id=folder_id,
-    )
-    session.add(feed)
-    session.commit()
-    session.refresh(feed)
-    return feed
-
-
-def _create_article(
-    session: Session,
-    *,
-    feed_id: int,
-    title: str,
-    url: str,
-    is_read: bool = False,
-    scoring_state: str = "scored",
-    composite_score: float = 1.0,
-) -> Article:
-    article = Article(
-        feed_id=feed_id,
-        title=title,
-        url=url,
-        is_read=is_read,
-        scoring_state=scoring_state,
-        composite_score=composite_score,
-        published_at=datetime.now(),
-    )
-    session.add(article)
-    session.commit()
-    session.refresh(article)
-    return article
 
 
 def test_create_folder_enforces_case_insensitive_name_uniqueness(
@@ -73,15 +27,14 @@ def test_create_folder_enforces_case_insensitive_name_uniqueness(
 def test_create_folder_assigns_selected_ungrouped_feeds(
     test_client: TestClient,
     test_session: Session,
+    make_feed: Callable[..., Feed],
 ):
-    feed_one = _create_feed(
-        test_session,
+    feed_one = make_feed(
         title="Feed One",
         url="https://example.com/feed-one.xml",
         display_order=5,
     )
-    feed_two = _create_feed(
-        test_session,
+    feed_two = make_feed(
         title="Feed Two",
         url="https://example.com/feed-two.xml",
         display_order=2,
@@ -110,21 +63,20 @@ def test_create_folder_assigns_selected_ungrouped_feeds(
 def test_create_folder_with_grouped_feed_fails_atomically(
     test_client: TestClient,
     test_session: Session,
+    make_feed: Callable[..., Feed],
 ):
     existing_folder = FeedFolder(name="Existing", display_order=0)
     test_session.add(existing_folder)
     test_session.commit()
     test_session.refresh(existing_folder)
 
-    already_grouped = _create_feed(
-        test_session,
+    already_grouped = make_feed(
         title="Grouped",
         url="https://example.com/grouped.xml",
         display_order=0,
         folder_id=existing_folder.id,
     )
-    still_ungrouped = _create_feed(
-        test_session,
+    still_ungrouped = make_feed(
         title="Ungrouped",
         url="https://example.com/ungrouped.xml",
         display_order=1,
@@ -152,27 +104,25 @@ def test_create_folder_with_grouped_feed_fails_atomically(
 def test_delete_folder_defaults_to_ungrouping_feeds(
     test_client: TestClient,
     test_session: Session,
+    make_feed: Callable[..., Feed],
 ):
     folder = FeedFolder(name="Tech", display_order=0)
     test_session.add(folder)
     test_session.commit()
     test_session.refresh(folder)
 
-    root_feed = _create_feed(
-        test_session,
+    root_feed = make_feed(
         title="Root",
         url="https://example.com/root.xml",
         display_order=3,
     )
-    folder_feed_one = _create_feed(
-        test_session,
+    folder_feed_one = make_feed(
         title="Folder A",
         url="https://example.com/folder-a.xml",
         display_order=0,
         folder_id=folder.id,
     )
-    folder_feed_two = _create_feed(
-        test_session,
+    folder_feed_two = make_feed(
         title="Folder B",
         url="https://example.com/folder-b.xml",
         display_order=1,
@@ -200,22 +150,22 @@ def test_delete_folder_defaults_to_ungrouping_feeds(
 def test_delete_folder_with_delete_feeds_removes_feeds_and_articles(
     test_client: TestClient,
     test_session: Session,
+    make_feed: Callable[..., Feed],
+    make_article: Callable[..., Article],
 ):
     folder = FeedFolder(name="Delete Me", display_order=0)
     test_session.add(folder)
     test_session.commit()
     test_session.refresh(folder)
 
-    feed = _create_feed(
-        test_session,
+    feed = make_feed(
         title="Delete Feed",
         url="https://example.com/delete-feed.xml",
         display_order=0,
         folder_id=folder.id,
     )
-    article = _create_article(
-        test_session,
-        feed_id=feed.id,
+    article = make_article(
+        feed.id,
         title="Delete Article",
         url="https://example.com/delete-article",
     )
@@ -235,21 +185,20 @@ def test_delete_folder_with_delete_feeds_removes_feeds_and_articles(
 def test_reorder_feeds_rejects_mixed_folder_payload(
     test_client: TestClient,
     test_session: Session,
+    make_feed: Callable[..., Feed],
 ):
     folder = FeedFolder(name="Scoped", display_order=0)
     test_session.add(folder)
     test_session.commit()
     test_session.refresh(folder)
 
-    folder_feed = _create_feed(
-        test_session,
+    folder_feed = make_feed(
         title="Folder Feed",
         url="https://example.com/folder-scope.xml",
         display_order=0,
         folder_id=folder.id,
     )
-    root_feed = _create_feed(
-        test_session,
+    root_feed = make_feed(
         title="Root Feed",
         url="https://example.com/root-scope.xml",
         display_order=0,
@@ -265,35 +214,33 @@ def test_reorder_feeds_rejects_mixed_folder_payload(
 def test_articles_can_be_filtered_by_folder(
     test_client: TestClient,
     test_session: Session,
+    make_feed: Callable[..., Feed],
+    make_article: Callable[..., Article],
 ):
     folder = FeedFolder(name="Filter Folder", display_order=0)
     test_session.add(folder)
     test_session.commit()
     test_session.refresh(folder)
 
-    folder_feed = _create_feed(
-        test_session,
+    folder_feed = make_feed(
         title="Folder Feed",
         url="https://example.com/filter-folder.xml",
         display_order=0,
         folder_id=folder.id,
     )
-    root_feed = _create_feed(
-        test_session,
+    root_feed = make_feed(
         title="Root Feed",
         url="https://example.com/filter-root.xml",
         display_order=0,
     )
 
-    folder_article = _create_article(
-        test_session,
-        feed_id=folder_feed.id,
+    folder_article = make_article(
+        folder_feed.id,
         title="Folder Article",
         url="https://example.com/folder-article",
     )
-    _create_article(
-        test_session,
-        feed_id=root_feed.id,
+    make_article(
+        root_feed.id,
         title="Root Article",
         url="https://example.com/root-article",
     )

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -81,6 +81,7 @@ dependencies = [
 dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "respx" },
     { name = "ruff" },
 ]
 
@@ -104,6 +105,7 @@ requires-dist = [
 dev = [
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "respx", specifier = ">=0.22.0" },
     { name = "ruff", specifier = ">=0.15.0" },
 ]
 
@@ -465,6 +467,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "respx"
+version = "0.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/7c/96bd0bc759cf009675ad1ee1f96535edcb11e9666b985717eb8c87192a95/respx-0.22.0.tar.gz", hash = "sha256:3c8924caa2a50bd71aefc07aa812f2466ff489f1848c96e954a5362d17095d91", size = 28439, upload-time = "2024-12-19T22:33:59.374Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/67/afbb0978d5399bc9ea200f1d4489a23c9a1dad4eee6376242b8182389c79/respx-0.22.0-py2.py3-none-any.whl", hash = "sha256:631128d4c9aba15e56903fb5f66fb1eff412ce28dd387ca3a81339e52dbd3ad0", size = 25127, upload-time = "2024-12-19T22:33:57.837Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Improve backend test infrastructure and add CI gating

## What is this PR about?

Overhauls the backend test foundation: fixes a lifespan contamination bug, switches to in-memory SQLite, adds factory fixtures, installs respx for HTTP mocking, gates backend tests in CI, and documents all patterns in the knowledge system.

## Why is this change needed?

The test infrastructure had several compounding issues: `TestClient` triggered production lifespan side-effects (DB creation, real scheduler), temp database files leaked, helpers were duplicated across test files, and backend tests weren't gated in CI. The frontend already had well-documented test patterns — this brings the backend to the same standard.

## How is this change implemented?

- Patch lifespan side-effects (`create_db_and_tables`, `start_scheduler`, etc.) to no-ops in `test_client` fixture
- Switch `test_engine` from temp-file SQLite to in-memory SQLite with `StaticPool`
- Add `make_feed`, `make_article`, `make_category` factory fixtures; refactor test files to use them
- Add `respx` dev dependency and `[tool.pytest.ini_options]` config
- Add `test-backend` CI job (uv + ruff + pytest) gating `build-and-push`
- Create `backend-testing` skill and add Testing rules section

## How to test this change?

1. Run `cd backend && uv run pytest -v` — all 62 tests should pass
2. Verify no temp `.db` files are created during test runs
3. Check that the CI `test-backend` job runs on push

## Notes

- Patterns inspired by SQLModel's own test suite, Polar, Mealie, and lemon24/reader
- `test_migrations.py` still uses temp files (Alembic needs real file paths) — intentionally unchanged
- `respx` is installed but no feed error tests written yet — that's separate work

🤖 Generated with [Claude Code](https://claude.com/claude-code)