### PR TITLE
Add feed-layer tests and RSS/Atom fixtures

### DIFF
--- a/backend/tests/fixtures/atom_atlantic_sample.xml
+++ b/backend/tests/fixtures/atom_atlantic_sample.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xml:lang="en-us" xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
+  <title>Technology | The Atlantic</title>
+  <link href="https://www.theatlantic.com/technology/" rel="alternate"/>
+  <link href="https://www.theatlantic.com/feed/channel/technology/" rel="self"/>
+  <id>https://www.theatlantic.com/technology/</id>
+  <updated>2026-02-28T11:00:00-05:00</updated>
+  <rights>Copyright 2026 by The Atlantic Monthly Group. All Rights Reserved.</rights>
+  <entry>
+    <id>tag:theatlantic.com,2026:50-686200</id>
+    <title type="html">What the Pentagon Really Wanted From Anthropic</title>
+    <published>2026-02-28T15:52:56-05:00</published>
+    <updated>2026-02-28T16:30:00-05:00</updated>
+    <author>
+      <name>Matt Schiavenza</name>
+      <uri>http://www.theatlantic.com/author/matt-schiavenza/?utm_source=feed</uri>
+    </author>
+    <summary type="html">The company believed it was close to a deal with the Defense Department.</summary>
+    <content type="html">&lt;p&gt;Right up until the moment, its leaders believed they were still on track for a deal.&lt;/p&gt;</content>
+    <link href="https://www.theatlantic.com/technology/2026/02/pentagon-anthropic-contract/686200/?utm_source=feed" rel="alternate" type="text/html"/>
+    <media:content url="https://cdn.theatlantic.com/thumbor/example/original.jpg">
+      <media:credit>Kevin Dietsch / Getty</media:credit>
+    </media:content>
+  </entry>
+  <entry>
+    <id>tag:theatlantic.com,2026:50-685913</id>
+    <title type="html">AI Regulation Moves to the States</title>
+    <published>2026-02-06T16:27:05-05:00</published>
+    <updated>2026-02-06T17:13:42-05:00</updated>
+    <author>
+      <name>Hana Kiros</name>
+      <uri>http://www.theatlantic.com/author/hana-kiros/?utm_source=feed</uri>
+    </author>
+    <summary type="html">As federal oversight stalls, state legislatures step in with their own AI bills.</summary>
+    <link href="https://www.theatlantic.com/technology/2026/02/ai-regulation-states/685913/?utm_source=feed" rel="alternate" type="text/html"/>
+    <media:content url="https://cdn.theatlantic.com/thumbor/example2/original.jpg">
+      <media:credit>AP Photo</media:credit>
+    </media:content>
+  </entry>
+</feed>

--- a/backend/tests/fixtures/atom_sample.xml
+++ b/backend/tests/fixtures/atom_sample.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test Atom Feed</title>
+  <link href="https://example.com"/>
+  <updated>2024-01-02T08:30:00Z</updated>
+  <entry>
+    <title>Atom Entry One</title>
+    <link href="https://example.com/atom-1"/>
+    <updated>2024-01-01T12:00:00Z</updated>
+    <author><name>Bob</name></author>
+    <summary>Summary of entry one.</summary>
+    <content type="html">&lt;p&gt;Full HTML content of entry one.&lt;/p&gt;</content>
+  </entry>
+  <entry>
+    <title>Atom Entry Two</title>
+    <link href="https://example.com/atom-2"/>
+    <updated>2024-01-02T08:30:00Z</updated>
+    <summary>Summary of entry two.</summary>
+  </entry>
+</feed>

--- a/backend/tests/fixtures/malformed_sample.xml
+++ b/backend/tests/fixtures/malformed_sample.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Broken Feed</title>
+    <item>
+      <title>Broken Entry
+      <link>https://example.com/broken</link>
+    </item>

--- a/backend/tests/fixtures/rss2_hn_sample.xml
+++ b/backend/tests/fixtures/rss2_hn_sample.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Hacker News: Front Page</title>
+    <link>https://news.ycombinator.com/</link>
+    <description>Hacker News RSS</description>
+    <docs>https://hnrss.org/</docs>
+    <generator>hnrss v2.1.1</generator>
+    <lastBuildDate>Mon, 02 Mar 2026 21:04:47 +0000</lastBuildDate>
+    <atom:link href="https://hnrss.org/frontpage" rel="self" type="application/rss+xml"/>
+    <item>
+      <title><![CDATA[Packaging a Gleam app into a single executable]]></title>
+      <description><![CDATA[
+        <p>Article URL: <a href="https://www.dhzdhd.dev/blog/gleam-executable">https://www.dhzdhd.dev/blog/gleam-executable</a></p>
+        <p>Comments URL: <a href="https://news.ycombinator.com/item?id=47220020">https://news.ycombinator.com/item?id=47220020</a></p>
+        <p>Points: 59</p>
+        <p># Comments: 3</p>
+      ]]></description>
+      <pubDate>Mon, 02 Mar 2026 16:20:18 +0000</pubDate>
+      <link>https://www.dhzdhd.dev/blog/gleam-executable</link>
+      <dc:creator>todsacerdoti</dc:creator>
+      <comments>https://news.ycombinator.com/item?id=47220020</comments>
+      <guid isPermaLink="false">https://news.ycombinator.com/item?id=47220020</guid>
+    </item>
+    <item>
+      <title><![CDATA[Notes on Lagrange Interpolating Polynomials]]></title>
+      <description><![CDATA[
+        <p>Article URL: <a href="https://eli.thegreenplace.net/2026/notes-on-lagrange-interpolating-polynomials/">https://eli.thegreenplace.net/2026/notes-on-lagrange-interpolating-polynomials/</a></p>
+        <p>Comments URL: <a href="https://news.ycombinator.com/item?id=47219688">https://news.ycombinator.com/item?id=47219688</a></p>
+        <p>Points: 32</p>
+        <p># Comments: 9</p>
+      ]]></description>
+      <pubDate>Mon, 02 Mar 2026 16:01:20 +0000</pubDate>
+      <link>https://eli.thegreenplace.net/2026/notes-on-lagrange-interpolating-polynomials/</link>
+      <dc:creator>ibobev</dc:creator>
+      <comments>https://news.ycombinator.com/item?id=47219688</comments>
+      <guid isPermaLink="false">https://news.ycombinator.com/item?id=47219688</guid>
+    </item>
+  </channel>
+</rss>

--- a/backend/tests/fixtures/rss2_sample.xml
+++ b/backend/tests/fixtures/rss2_sample.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test RSS Feed</title>
+    <link>https://example.com</link>
+    <description>A test RSS 2.0 feed</description>
+    <item>
+      <title>First Article</title>
+      <link>https://example.com/article-1</link>
+      <author>Alice</author>
+      <pubDate>Mon, 01 Jan 2024 12:00:00 GMT</pubDate>
+      <description>Summary of the first article.</description>
+    </item>
+    <item>
+      <title>Second Article</title>
+      <link>https://example.com/article-2</link>
+      <pubDate>Tue, 02 Jan 2024 08:30:00 GMT</pubDate>
+      <description>Summary of the second article.</description>
+    </item>
+  </channel>
+</rss>

--- a/backend/tests/test_fetch_feed.py
+++ b/backend/tests/test_fetch_feed.py
@@ -1,0 +1,142 @@
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+
+from backend.feeds import fetch_feed
+
+_FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+FEED_URL = "https://example.com/feed.xml"
+
+
+def _read_fixture(filename: str) -> str:
+    return (_FIXTURES_DIR / filename).read_text()
+
+
+# --- Valid feeds ---
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_fetch_rss2():
+    xml = _read_fixture("rss2_sample.xml")
+    respx.get(FEED_URL).mock(return_value=httpx.Response(200, text=xml))
+
+    feed = await fetch_feed(FEED_URL)
+
+    assert feed.bozo == 0
+    assert feed.feed.title == "Test RSS Feed"
+    assert len(feed.entries) == 2
+    assert feed.entries[0].link == "https://example.com/article-1"
+    assert feed.entries[1].link == "https://example.com/article-2"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_fetch_atom():
+    xml = _read_fixture("atom_sample.xml")
+    respx.get(FEED_URL).mock(return_value=httpx.Response(200, text=xml))
+
+    feed = await fetch_feed(FEED_URL)
+
+    assert feed.bozo == 0
+    assert feed.feed.title == "Test Atom Feed"
+    assert len(feed.entries) == 2
+    assert feed.entries[0].link == "https://example.com/atom-1"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_fetch_rss2_with_dc_creator_and_cdata():
+    """Real-world HN RSS: dc:creator for author, CDATA-wrapped title/description."""
+    xml = _read_fixture("rss2_hn_sample.xml")
+    respx.get(FEED_URL).mock(return_value=httpx.Response(200, text=xml))
+
+    feed = await fetch_feed(FEED_URL)
+
+    assert feed.bozo == 0
+    assert feed.feed.title == "Hacker News: Front Page"
+    assert len(feed.entries) == 2
+    # feedparser normalizes dc:creator → entry.author
+    assert feed.entries[0].author == "todsacerdoti"
+    # CDATA is stripped transparently
+    assert feed.entries[0].title == "Packaging a Gleam app into a single executable"
+    assert feed.entries[0].link == "https://www.dhzdhd.dev/blog/gleam-executable"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_fetch_atom_with_media_namespace():
+    """Real-world Atlantic Atom: media: namespace, author with uri, title type=html."""
+    xml = _read_fixture("atom_atlantic_sample.xml")
+    respx.get(FEED_URL).mock(return_value=httpx.Response(200, text=xml))
+
+    feed = await fetch_feed(FEED_URL)
+
+    assert feed.bozo == 0
+    assert feed.feed.title == "Technology | The Atlantic"
+    assert len(feed.entries) == 2
+    # Per-entry author (not feed-level)
+    assert feed.entries[0].author == "Matt Schiavenza"
+    # Atom link with rel=alternate and type=text/html
+    assert "686200" in feed.entries[0].link
+    # summary and content both present
+    assert feed.entries[0].summary is not None
+    assert feed.entries[0].content[0].value is not None
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_fetch_malformed_xml():
+    xml = _read_fixture("malformed_sample.xml")
+    respx.get(FEED_URL).mock(return_value=httpx.Response(200, text=xml))
+
+    feed = await fetch_feed(FEED_URL)
+
+    assert feed.bozo == 1
+
+
+# --- HTTP error responses ---
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_fetch_http_404():
+    respx.get(FEED_URL).mock(return_value=httpx.Response(404))
+
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        await fetch_feed(FEED_URL)
+    assert exc_info.value.response.status_code == 404
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_fetch_http_500():
+    respx.get(FEED_URL).mock(return_value=httpx.Response(500))
+
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        await fetch_feed(FEED_URL)
+    assert exc_info.value.response.status_code == 500
+
+
+# --- Network errors ---
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_fetch_timeout():
+    respx.get(FEED_URL).mock(side_effect=httpx.ConnectTimeout("timed out"))
+
+    with pytest.raises(httpx.ConnectTimeout):
+        await fetch_feed(FEED_URL)
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_fetch_connection_error():
+    respx.get(FEED_URL).mock(side_effect=httpx.ConnectError("connection refused"))
+
+    with pytest.raises(httpx.ConnectError):
+        await fetch_feed(FEED_URL)

--- a/backend/tests/test_save_articles.py
+++ b/backend/tests/test_save_articles.py
@@ -1,0 +1,141 @@
+from collections.abc import Callable
+from datetime import datetime
+from time import struct_time
+
+from sqlmodel import Session, select
+
+from backend.feeds import _parse_published_date, save_articles
+from backend.models import Article, Feed
+
+# --- _parse_published_date tests (pure function, no fixtures) ---
+
+
+def test_parse_date_published_parsed():
+    # struct_time: (year, month, day, hour, minute, second, weekday, julian_day, dst)
+    entry = {"published_parsed": struct_time((2024, 1, 15, 10, 30, 0, 0, 15, 0))}
+
+    result = _parse_published_date(entry)
+
+    assert result == datetime(2024, 1, 15, 10, 30, 0)
+
+
+def test_parse_date_updated_fallback():
+    entry = {"updated_parsed": struct_time((2024, 6, 1, 8, 0, 0, 5, 153, 0))}
+
+    result = _parse_published_date(entry)
+
+    assert result == datetime(2024, 6, 1, 8, 0, 0)
+
+
+def test_parse_date_none():
+    result = _parse_published_date({})
+
+    assert result is None
+
+
+# --- save_articles tests (sync, use test_session + make_feed) ---
+
+
+def test_save_basic(test_session: Session, make_feed: Callable[..., Feed]):
+    feed = make_feed()
+    entries = [
+        {"link": "https://example.com/a1", "title": "Article One"},
+        {"link": "https://example.com/a2", "title": "Article Two"},
+    ]
+
+    new_count, new_ids = save_articles(test_session, feed.id, entries)
+
+    assert new_count == 2
+    assert len(new_ids) == 2
+    articles = test_session.exec(select(Article)).all()
+    assert len(articles) == 2
+
+
+def test_save_deduplication(
+    test_session: Session,
+    make_feed: Callable[..., Feed],
+    make_article: Callable[..., Article],
+):
+    feed = make_feed()
+    make_article(feed.id, url="https://example.com/existing")
+    entries = [{"link": "https://example.com/existing", "title": "Duplicate"}]
+
+    new_count, new_ids = save_articles(test_session, feed.id, entries)
+
+    assert new_count == 0
+    assert new_ids == []
+
+
+def test_save_mixed_new_and_existing(
+    test_session: Session,
+    make_feed: Callable[..., Feed],
+    make_article: Callable[..., Article],
+):
+    feed = make_feed()
+    make_article(feed.id, url="https://example.com/old")
+    entries = [
+        {"link": "https://example.com/old", "title": "Existing"},
+        {"link": "https://example.com/new-1", "title": "New One"},
+        {"link": "https://example.com/new-2", "title": "New Two"},
+    ]
+
+    new_count, new_ids = save_articles(test_session, feed.id, entries)
+
+    assert new_count == 2
+    assert len(new_ids) == 2
+
+
+def test_save_skips_no_link(test_session: Session, make_feed: Callable[..., Feed]):
+    feed = make_feed()
+    entries = [{"title": "No Link Entry"}]
+
+    new_count, new_ids = save_articles(test_session, feed.id, entries)
+
+    assert new_count == 0
+    assert new_ids == []
+
+
+def test_save_field_fallbacks(test_session: Session, make_feed: Callable[..., Feed]):
+    feed = make_feed()
+    entries = [{"link": "https://example.com/minimal"}]
+
+    save_articles(test_session, feed.id, entries)
+
+    article = test_session.exec(
+        select(Article).where(Article.url == "https://example.com/minimal")
+    ).one()
+    assert article.title == "Untitled"
+    assert article.author is None
+    assert article.published_at is None
+    assert article.summary is None
+    assert article.content is None
+    assert article.is_read is False
+
+
+def test_save_content_extraction(
+    test_session: Session, make_feed: Callable[..., Feed]
+):
+    feed = make_feed()
+    entries = [
+        {
+            "link": "https://example.com/with-content",
+            "title": "Has Content",
+            "content": [{"value": "<p>Full body here.</p>"}],
+        }
+    ]
+
+    save_articles(test_session, feed.id, entries)
+
+    article = test_session.exec(
+        select(Article).where(Article.url == "https://example.com/with-content")
+    ).one()
+    assert article.content == "<p>Full body here.</p>"
+
+
+def test_save_empty_entries(test_session: Session, make_feed: Callable[..., Feed]):
+    feed = make_feed()
+
+    new_count, new_ids = save_articles(test_session, feed.id, [])
+
+    assert new_count == 0
+    assert new_ids == []


### PR DESCRIPTION
# Add feed-layer tests and RSS/Atom fixtures

## What is this PR about?

Adds dedicated unit tests for `fetch_feed` and `save_articles` — the two core functions in the feed-fetching pipeline — along with sample XML fixture files for both synthetic and real-world feeds.

## Why is this change needed?

PR #8 set up the backend test infrastructure but intentionally excluded new test files. The feed-fetching and parsing layer had zero dedicated test coverage, leaving error handling, deduplication logic, and field-fallback behavior unverified.

## How is this change implemented?

- 5 XML fixture files in `backend/tests/fixtures/`: RSS 2.0, Atom, malformed XML, plus real-world samples from HN and The Atlantic
- `test_fetch_feed.py`: 9 async tests using `respx` covering valid feeds, HTTP errors (404/500), network errors (timeout/connection), and real-world feed quirks (dc:creator, CDATA, media: namespace)
- `test_save_articles.py`: 10 sync tests covering `_parse_published_date` (3 tests) and `save_articles` deduplication, field fallbacks, content extraction, and edge cases (7 tests)

## How to test this change?

1. `cd backend && uv run pytest tests/test_fetch_feed.py tests/test_save_articles.py -v` — all 19 new tests pass
2. `cd backend && uv run pytest` — full suite (81 tests) green
3. `cd backend && uv run ruff check .` — no new lint errors

## Notes

- First use of `respx` in the test suite — establishes the pattern for future HTTP-layer tests
- No changes to existing files; purely additive

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)