### PR TITLE
Fix hydration error and unread article vanishing

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -9,6 +9,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@emotion/cache": "^11.14.0",
         "@emotion/react": "^11.14.0",
         "@tanstack/react-query": "^5.90.20",
         "html-react-parser": "^5.2.17",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@emotion/cache": "^11.14.0",
     "@emotion/react": "^11.14.0",
     "@tanstack/react-query": "^5.90.20",
     "html-react-parser": "^5.2.17",

--- a/frontend/src/components/ui/emotion-registry.tsx
+++ b/frontend/src/components/ui/emotion-registry.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useState } from "react";
+import { useServerInsertedHTML } from "next/navigation";
+import createCache from "@emotion/cache";
+import { CacheProvider } from "@emotion/react";
+
+export function EmotionRegistry({ children }: { children: React.ReactNode }) {
+  const [cache] = useState(() => {
+    const c = createCache({ key: "css" });
+    c.compat = true;
+    return c;
+  });
+
+  useServerInsertedHTML(() => {
+    const names = Object.keys(cache.inserted);
+    if (names.length === 0) return null;
+    let styles = "";
+    for (const name of names) {
+      if (cache.inserted[name] !== true) {
+        styles += cache.inserted[name];
+      }
+    }
+    return (
+      <style
+        data-emotion={`${cache.key} ${names.join(" ")}`}
+        dangerouslySetInnerHTML={{ __html: styles }}
+      />
+    );
+  });
+
+  return <CacheProvider value={cache}>{children}</CacheProvider>;
+}

--- a/frontend/src/components/ui/provider.tsx
+++ b/frontend/src/components/ui/provider.tsx
@@ -7,12 +7,15 @@ import {
 } from "./color-mode"
 import { system } from "@/theme"
 import { Toaster } from "./toaster"
+import { EmotionRegistry } from "./emotion-registry"
 
 export function Provider(props: ColorModeProviderProps) {
   return (
-    <ChakraProvider value={system}>
-      <ColorModeProvider {...props} />
-      <Toaster />
-    </ChakraProvider>
+    <EmotionRegistry>
+      <ChakraProvider value={system}>
+        <ColorModeProvider {...props} />
+        <Toaster />
+      </ChakraProvider>
+    </EmotionRegistry>
   )
 }

--- a/frontend/src/hooks/useArticles.ts
+++ b/frontend/src/hooks/useArticles.ts
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { fetchArticles, updateArticleReadStatus } from "@/lib/api";
 import { queryKeys } from "@/lib/queryKeys";
+import type { ArticleListItem } from "@/lib/types";
 
 const PAGE_SIZE = 50;
 const SCORING_ACTIVE_POLL_INTERVAL = 10_000;
@@ -86,8 +87,24 @@ export function useMarkAsRead() {
       isRead: boolean;
     }) => updateArticleReadStatus(articleId, isRead),
     meta: { errorTitle: "Failed to update article" },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.articles.all });
+    onSuccess: (_, { articleId, isRead }) => {
+      // Update is_read in cached article lists without removing the article.
+      queryClient.setQueriesData<ArticleListItem[]>(
+        { queryKey: queryKeys.articles.all },
+        (oldData) => {
+          if (!oldData || !Array.isArray(oldData)) return oldData;
+          return oldData.map((a) =>
+            a.id === articleId ? { ...a, is_read: isRead } : a
+          );
+        }
+      );
+      // Mark all article queries as invalid so they refetch on next observe
+      // (tab switch, feed switch) — but don't refetch the active query now,
+      // so the article stays visible in the current view.
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.articles.all,
+        refetchType: "none",
+      });
     },
   });
 }


### PR DESCRIPTION
# Fix hydration error and unread article vanishing

## What is this PR about?

Fixes two frontend bugs: an intermittent hydration mismatch on the settings sidebar, and articles disappearing from the unread list when auto-marked as read.

## Why is this change needed?

The hydration error produces console warnings and can cause visual flicker. The vanishing article bug closes the reader mid-read when the 12-second auto-mark timer fires, which is disruptive.

## How is this change implemented?

- Added an Emotion SSR cache registry (`EmotionRegistry`) using `useServerInsertedHTML` to serialize server-generated styles into the HTML, so the client reuses them during hydration
- Wrapped `ChakraProvider` with the new `EmotionRegistry` in the root provider
- Replaced `invalidateQueries` with `setQueriesData` in `useMarkAsRead` to update `is_read` in-place without removing articles from cached lists
- Added deferred `invalidateQueries({ refetchType: "none" })` so queries refetch on next observe (tab/feed switch) but not while the user is reading

## How to test this change?

1. Load `/settings` with a full page refresh — check console for hydration warnings (should be gone)
2. On the Unread tab, open an article and wait 12+ seconds — article should dim but stay in the list, reader stays open
3. Click the unread dot on a different article — dot disappears, article stays in list
4. Switch to "All" tab, then back to "Unread" — previously-read articles should be gone
5. Switch between feeds — read articles should not persist in the unread list

## Notes

- If the hydration warning persists despite the Emotion registry, it means Chakra's internal CacheProvider is shadowing ours — the registry can be safely removed and the issue documented as upstream Chakra bug
- Active scoring polls every 5-10s and replaces the cache, which is acceptable since the list is actively changing during scoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)