### PR TITLE
fix(backend): resolve ruff lint and format violations

### DIFF
--- a/.claude/hooks/lint-on-save.sh
+++ b/.claude/hooks/lint-on-save.sh
@@ -3,7 +3,9 @@ input=$(cat)
 file_path=$(echo "$input" | jq -r '.tool_input.file_path')
 
 if [[ "$file_path" == */backend/*.py ]]; then
-  cd backend && uv run ruff check "$file_path" 2>&1 || true
+  cd backend
+  uv run ruff check "$file_path" 2>&1 || true
+  uv run ruff format --check --diff "$file_path" 2>&1 || true
 elif [[ "$file_path" == */frontend/*.ts ]] || [[ "$file_path" == */frontend/*.tsx ]]; then
   cd frontend && bunx eslint "$file_path" 2>&1 || true
 fi

--- a/backend/alembic/versions/1c3cc7f7d174_rename_use_separate_models_drop_legacy_.py
+++ b/backend/alembic/versions/1c3cc7f7d174_rename_use_separate_models_drop_legacy_.py
@@ -39,12 +39,12 @@ def upgrade() -> None:
     bind = op.get_bind()
     inspector = sa.inspect(bind)
 
-    if not any(
-        t == "user_preferences" for t in inspector.get_table_names()
-    ):
+    if not any(t == "user_preferences" for t in inspector.get_table_names()):
         return
 
-    has_old = _column_exists(inspector, "user_preferences", "ollama_use_separate_models")
+    has_old = _column_exists(
+        inspector, "user_preferences", "ollama_use_separate_models"
+    )
     has_new = _column_exists(inspector, "user_preferences", "use_separate_models")
 
     # SQLite doesn't support ALTER COLUMN RENAME directly -- use batch mode
@@ -78,9 +78,7 @@ def downgrade() -> None:
     bind = op.get_bind()
     inspector = sa.inspect(bind)
 
-    if not any(
-        t == "user_preferences" for t in inspector.get_table_names()
-    ):
+    if not any(t == "user_preferences" for t in inspector.get_table_names()):
         return
 
     with op.batch_alter_table("user_preferences") as batch_op:

--- a/backend/alembic/versions/dff7a4c52b3c_llm_providers_task_routes.py
+++ b/backend/alembic/versions/dff7a4c52b3c_llm_providers_task_routes.py
@@ -207,7 +207,9 @@ def upgrade() -> None:
     # Guard: legacy columns may not exist on fresh installs where models.py
     # no longer defines them (removed in Phase 09.6).
     inspector = sa.inspect(bind)
-    has_legacy_cols = _column_exists(inspector, "user_preferences", "ollama_categorization_model")
+    has_legacy_cols = _column_exists(
+        inspector, "user_preferences", "ollama_categorization_model"
+    )
 
     if has_legacy_cols:
         legacy = (

--- a/backend/alembic/versions/f0eb5e5b8e8c_merge_folders_and_rename_models.py
+++ b/backend/alembic/versions/f0eb5e5b8e8c_merge_folders_and_rename_models.py
@@ -5,17 +5,14 @@ Revises: 1c3cc7f7d174, 55f0f2e37b8a
 Create Date: 2026-03-01 16:22:28.859180
 
 """
-from typing import Sequence, Union
 
-from alembic import op
-import sqlalchemy as sa
-
+from collections.abc import Sequence
 
 # revision identifiers, used by Alembic.
-revision: str = 'f0eb5e5b8e8c'
-down_revision: Union[str, Sequence[str], None] = ('1c3cc7f7d174', '55f0f2e37b8a')
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+revision: str = "f0eb5e5b8e8c"
+down_revision: str | Sequence[str] | None = ("1c3cc7f7d174", "55f0f2e37b8a")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/backend/src/backend/routers/ollama.py
+++ b/backend/src/backend/routers/ollama.py
@@ -127,7 +127,8 @@ def get_task_routes(session: Session = Depends(get_session)):
     preferences = get_or_create_preferences(session)
     return TaskRoutesResponse(
         routes=[
-            TaskRouteItem(task=r.task, provider=r.provider, model=r.model) for r in routes
+            TaskRouteItem(task=r.task, provider=r.provider, model=r.model)
+            for r in routes
         ],
         use_separate_models=preferences.use_separate_models,
     )
@@ -140,11 +141,12 @@ def save_task_routes(
 ):
     """Save model assignments and use_separate_models preference."""
     upsert_task_route(
-        session, TASK_CATEGORIZATION, data.categorization.provider, data.categorization.model
+        session,
+        TASK_CATEGORIZATION,
+        data.categorization.provider,
+        data.categorization.model,
     )
-    upsert_task_route(
-        session, TASK_SCORING, data.scoring.provider, data.scoring.model
-    )
+    upsert_task_route(session, TASK_SCORING, data.scoring.provider, data.scoring.model)
 
     preferences = get_or_create_preferences(session)
     preferences.use_separate_models = data.use_separate_models
@@ -171,13 +173,19 @@ async def list_available_models(session: Session = Depends(get_session)):
             continue
 
         try:
-            config = get_ollama_provider_config(session) if row.provider == OLLAMA_PROVIDER else None
+            config = (
+                get_ollama_provider_config(session)
+                if row.provider == OLLAMA_PROVIDER
+                else None
+            )
             endpoint = config.endpoint if config else None
             if endpoint is None:
                 continue
             models = await provider.list_models(endpoint)
         except Exception:
-            logger.warning("Failed to list models for provider: %s", row.provider, exc_info=True)
+            logger.warning(
+                "Failed to list models for provider: %s", row.provider, exc_info=True
+            )
             continue
 
         for m in models:

--- a/backend/tests/test_categories_batch_move.py
+++ b/backend/tests/test_categories_batch_move.py
@@ -1,6 +1,6 @@
 """Tests for category batch-move safety constraints."""
 
-from typing import Callable
+from collections.abc import Callable
 
 from fastapi.testclient import TestClient
 from sqlmodel import Session

--- a/backend/tests/test_feed_folders_api.py
+++ b/backend/tests/test_feed_folders_api.py
@@ -1,6 +1,6 @@
 """Integration tests for feed folder endpoints and folder-aware feed/article behavior."""
 
-from typing import Callable
+from collections.abc import Callable
 
 from fastapi.testclient import TestClient
 from sqlmodel import Session, select

--- a/backend/tests/test_save_articles.py
+++ b/backend/tests/test_save_articles.py
@@ -112,9 +112,7 @@ def test_save_field_fallbacks(test_session: Session, make_feed: Callable[..., Fe
     assert article.is_read is False
 
 
-def test_save_content_extraction(
-    test_session: Session, make_feed: Callable[..., Feed]
-):
+def test_save_content_extraction(test_session: Session, make_feed: Callable[..., Feed]):
     feed = make_feed()
     entries = [
         {


### PR DESCRIPTION
# fix(backend): resolve ruff lint and format violations

## What is this PR about?

Fixes all ruff lint and formatting violations in the backend, and enhances the Claude Code lint-on-save hook to also catch formatting issues going forward.

## Why is this change needed?

`ruff check` found 10 lint issues and `ruff format` found 5 formatting violations that had accumulated. The existing lint hook only checked lint rules, not formatting.

## How is this change implemented?

- Auto-fixed 10 lint issues: outdated `typing` imports → `collections.abc`, unused imports, `Union[X, Y]` → `X | Y` syntax
- Auto-formatted 5 files with formatting drift (line wrapping, parenthesization)
- Added `ruff format --check --diff` to `.claude/hooks/lint-on-save.sh` so formatting violations are surfaced after every Write/Edit

## How to test this change?

1. Run `cd backend && uv run ruff check .` — should report 0 errors
2. Run `uv run ruff format --check .` — should report 0 formatting issues
3. Run `uv run pytest` — all 81 tests should pass

## Notes

- All fixes are mechanical (auto-applied by ruff), no behavioral changes
- The hook uses `--check --diff` (report-only), not auto-fix, to avoid diverging Claude's in-memory file state from disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)