### PR TITLE
fix(backend): include Alembic files in Docker runtime image

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -21,6 +21,7 @@ paths: ["backend/**"]
 - Don't use raw SQL to INSERT into ORM-modeled tables — bypasses Python-level defaults (`Field(default=...)`) and breaks when new NOT NULL columns are added. Use `Session(bind=conn)` + ORM objects instead.
 - After merging branches with Alembic migrations, run `alembic heads` — if multiple heads exist, run `alembic merge heads -m "merge_<description>"` before committing.
 - Never hold a write transaction open across slow I/O (LLM calls, network requests). Use short atomic commits and `session.no_autoflush` to prevent SELECTs from triggering implicit flushes.
+- When modifying the Dockerfile runtime stage, ensure `alembic.ini` and `alembic/` are copied — migrations silently skip if missing (see skill: backend-reference).
 
 ## Dependencies & Background Jobs
 

--- a/.claude/rules/critical-patterns.md
+++ b/.claude/rules/critical-patterns.md
@@ -29,3 +29,21 @@ code or command that avoids the problem
 
 Why: One-line explanation of the root cause.
 -->
+
+## Multi-stage Docker build must include Alembic files
+
+WRONG:
+```dockerfile
+# Runtime stage — only copies source
+COPY --from=builder /app/src /app/src
+```
+
+CORRECT:
+```dockerfile
+# Runtime stage — copies source AND migration infrastructure
+COPY --from=builder /app/src /app/src
+COPY --from=builder /app/alembic.ini /app/alembic.ini
+COPY --from=builder /app/alembic /app/alembic
+```
+
+Why: Alembic migrations silently skip when config is missing, causing schema drift that crashes at first ORM query.

--- a/.claude/skills/backend-reference/SKILL.md
+++ b/.claude/skills/backend-reference/SKILL.md
@@ -50,9 +50,15 @@ unscored -> queued -> scoring -> scored (or failed)
 - Articles with score 0 (all categories blocked) appear only in the Blocked tab
 - `database.py` resets articles stuck in `scoring_state='scoring'` back to `queued` on startup, handling cases where the process was killed mid-scoring
 
-## Schema Versioning
+## Schema Versioning (Dual-Layer)
 
-`database.py` uses a `schema_version` table with a `CURRENT_SCHEMA_VERSION` constant. Version-gated migrations run on startup -- each version check runs once, not every startup.
+Migrations run in two layers during `create_db_and_tables()` in `database.py`:
+
+**Layer 1 — schema_version bootstrap:** A hand-rolled `schema_version` table gates v0→v1→v2 migrations (seed default categories, add `feed_refresh_interval`). Each version check runs once, not every startup. This layer is frozen — no new versions will be added.
+
+**Layer 2 — Alembic:** All schema changes after v2 are managed by Alembic (`_run_alembic_migrations()`). The function locates `alembic.ini` via `Path(__file__).resolve().parents[2]` (project root) and runs `alembic upgrade head`.
+
+**Docker caveat:** The Dockerfile runtime stage must explicitly COPY `alembic.ini` and `alembic/` from the builder — if missing, `_run_alembic_migrations()` logs a warning and silently skips, leaving the database schema behind the ORM models.
 
 ## SQLite Configuration
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -40,6 +40,8 @@ WORKDIR /app
 # Copy virtual environment and source from builder
 COPY --from=builder /app/.venv /app/.venv
 COPY --from=builder /app/src /app/src
+COPY --from=builder /app/alembic.ini /app/alembic.ini
+COPY --from=builder /app/alembic /app/alembic
 
 # Set environment variables
 ENV PATH="/app/.venv/bin:$PATH" \


### PR DESCRIPTION
## What is this PR about?

Adds missing `alembic.ini` and `alembic/` COPY lines to the Dockerfile runtime stage so Alembic migrations actually run in production.

## Why is this change needed?

After the last merge to main, the production container crashes on startup with `no such column: user_preferences.use_separate_models`. The multi-stage Dockerfile only copied `/app/src`, omitting Alembic infrastructure — so migrations silently skipped and the DB schema fell behind the ORM models.

## How is this change implemented?

- Added two `COPY --from=builder` lines to `backend/Dockerfile` for `alembic.ini` and `alembic/`
- Added a WRONG/CORRECT critical pattern to prevent recurrence
- Updated backend rules and skills to document the dual-layer migration system

## How to test this change?

1. Build the Docker image: `cd backend && docker build -t rss-backend-test .`
2. Verify files exist: `docker run --rm rss-backend-test ls -la /app/alembic.ini /app/alembic/`
3. Run the container with a database volume and confirm startup completes without errors

## Notes

- This is a production hotfix — after merging to dev, please PR dev → main promptly
- The Alembic warning log ("config not found") was silently swallowed, masking the real issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)