### PR TITLE
fix: persist sidebar folder open/closed state (closes #24)

### DIFF
--- a/frontend/src/components/layout/MobileSidebar.tsx
+++ b/frontend/src/components/layout/MobileSidebar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
 import {
   Badge,
   Box,
@@ -75,9 +76,7 @@ export function MobileSidebar({
 
   const [feedToDelete, setFeedToDelete] = useState<Feed | null>(null);
   const [feedToMove, setFeedToMove] = useState<Feed | null>(null);
-  const [expandedFolders, setExpandedFolders] = useState<
-    Record<number, boolean>
-  >({});
+  const [expandedFolders, setExpandedFolders] = useLocalStorage<Record<number, boolean>>("expanded-folders", {});
 
   const { data: newCatCount } = useQuery({
     queryKey: queryKeys.categories.newCount,

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
 import {
   Badge,
   Box,
@@ -79,7 +80,7 @@ export function Sidebar({
 
   const [feedToDelete, setFeedToDelete] = useState<Feed | null>(null);
   const [feedToMove, setFeedToMove] = useState<Feed | null>(null);
-  const [expandedFolders, setExpandedFolders] = useState<Record<number, boolean>>({});
+  const [expandedFolders, setExpandedFolders] = useLocalStorage<Record<number, boolean>>("expanded-folders", {});
 
   const { data: newCatCount } = useQuery({
     queryKey: queryKeys.categories.newCount,

--- a/frontend/src/hooks/useLocalStorage.ts
+++ b/frontend/src/hooks/useLocalStorage.ts
@@ -1,11 +1,11 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, type SetStateAction } from "react";
 
 export function useLocalStorage<T>(
   key: string,
   initialValue: T
-): [T, (value: T) => void] {
+): [T, (value: SetStateAction<T>) => void] {
   const [storedValue, setStoredValue] = useState<T>(initialValue);
 
   // Sync from localStorage after hydration to avoid SSR mismatch
@@ -20,13 +20,16 @@ export function useLocalStorage<T>(
     }
   }, [key]);
 
-  const setValue = (value: T) => {
-    setStoredValue(value);
-    try {
-      window.localStorage.setItem(key, JSON.stringify(value));
-    } catch {
-      // Ignore write errors (e.g., quota exceeded)
-    }
+  const setValue = (value: SetStateAction<T>) => {
+    setStoredValue((prev) => {
+      const newValue = value instanceof Function ? value(prev) : value;
+      try {
+        window.localStorage.setItem(key, JSON.stringify(newValue));
+      } catch {
+        // Ignore write errors (e.g., quota exceeded)
+      }
+      return newValue;
+    });
   };
 
   return [storedValue, setValue];


### PR DESCRIPTION
# fix: persist sidebar folder open/closed state

## What is this PR about?

Feed folder expand/collapse state in the sidebar now survives page refreshes by storing it in localStorage under the key `"expanded-folders"`.

## Why is this change needed?

Users who collapse folders to reduce sidebar clutter would lose that arrangement on every page reload, forcing them to re-collapse folders each session.

## How is this change implemented?

- `useLocalStorage` updated to accept `SetStateAction<T>` (direct value or functional updater), matching the React `useState` API
- `Sidebar.tsx` and `MobileSidebar.tsx` swap `useState` for `useLocalStorage` for the `expandedFolders` state
- Both sidebars share the same `"expanded-folders"` key, so state is consistent between desktop and mobile views

## How to test this change?

1. Open the app with at least one feed folder visible in the sidebar
2. Collapse a folder by clicking it
3. Refresh the page
4. The folder should remain collapsed

## Notes

- Default behaviour is unchanged: folders start expanded (the empty `{}` initial value resolves to `true` via the existing `?? true` fallback in render logic)
- Pre-existing lint errors are unrelated to this change