### PR TITLE
fix: mobile sidebar layout and sticky reader header dot shift

### DIFF
--- a/frontend/src/components/article/ArticleRow.tsx
+++ b/frontend/src/components/article/ArticleRow.tsx
@@ -73,13 +73,9 @@ export const ArticleRow = React.memo(React.forwardRef<HTMLDivElement, ArticleRow
         css: isCompleting ? { animation: `${scoreReveal} 3s ease-out forwards` } : undefined,
       })}
     >
-      {/* Read/unread toggle dot - only render for unread articles */}
-      {!article.is_read && (
-        <Box
-          overflow="hidden"
-          transition="max-height 0.2s ease, opacity 0.15s ease"
-          {...(isExpanded ? { maxH: 0, opacity: 0 } : { maxH: "10", opacity: 1 })}
-        >
+      {/* Read/unread toggle dot - hidden in expanded/sticky header to prevent layout shift */}
+      {!isExpanded && !article.is_read && (
+        <Box>
           <Box
             flexShrink={0}
             alignSelf="center"

--- a/frontend/src/components/layout/MobileSidebar.tsx
+++ b/frontend/src/components/layout/MobileSidebar.tsx
@@ -76,7 +76,9 @@ export function MobileSidebar({
 
   const [feedToDelete, setFeedToDelete] = useState<Feed | null>(null);
   const [feedToMove, setFeedToMove] = useState<Feed | null>(null);
-  const [expandedFolders, setExpandedFolders] = useLocalStorage<Record<number, boolean>>("expanded-folders", {});
+  const [expandedFolders, setExpandedFolders] = useLocalStorage<
+    Record<number, boolean>
+  >("expanded-folders", {});
 
   const { data: newCatCount } = useQuery({
     queryKey: queryKeys.categories.newCount,
@@ -230,6 +232,7 @@ export function MobileSidebar({
                 <Flex
                   alignItems='center'
                   justifyContent='space-between'
+                  px={4}
                   py={3}
                   cursor='pointer'
                   bg={
@@ -405,7 +408,7 @@ export function MobileSidebar({
                 <ThemeToggle colorPalette='accent' />
               </Flex>
 
-              <Flex gap={2}>
+              <Flex direction='column' gap={2}>
                 <Button
                   variant='outline'
                   width='100%'
@@ -415,7 +418,6 @@ export function MobileSidebar({
                   <LuFolderPlus /> Create folder
                 </Button>
                 <Button
-                  variant='outline'
                   width='100%'
                   onClick={onAddFeedClick}
                   colorPalette='accent'


### PR DESCRIPTION
# fix: mobile sidebar layout and sticky reader header dot shift

## What is this PR about?

Three small UI bug fixes in the mobile sidebar and article reader header.

## Why is this change needed?

The unread dot in the sticky article reader header caused the title to jump left when an article was marked as read. The mobile sidebar's add-feed/add-folder buttons were laid out horizontally, pushing the add-feed button off-screen. The "All Articles" row was missing horizontal padding.

## How is this change implemented?

- `ArticleRow.tsx`: Exclude unread dot from DOM when row is in expanded/sticky mode (`!isExpanded && !article.is_read`), eliminating the layout shift on read
- `MobileSidebar.tsx`: Stack add-folder/add-feed buttons vertically and make add-feed the primary (solid) button (fixes #32)
- `MobileSidebar.tsx`: Add `px={4}` to the "All Articles" row to match surrounding padding

## How to test this change?

1. Open the app on a mobile viewport
2. Open the sidebar — both buttons should be stacked vertically, "Add feed" solid orange
3. Tap any unread article to open the reader — the title should not jump when the article is auto-marked as read
4. Verify the "All Articles" row has consistent left padding

## Notes

- Fixes #30 and #32