### PR TITLE
feat: update provider card layout and configured badge (#36, #37)

### DIFF
--- a/frontend/src/components/settings/AddProviderDialog.tsx
+++ b/frontend/src/components/settings/AddProviderDialog.tsx
@@ -26,7 +26,7 @@ export function AddProviderDialog({
           </Dialog.Header>
           <Dialog.Body>
             <Grid
-              templateColumns="repeat(auto-fill, minmax(180px, 1fr))"
+              templateColumns={{ base: "1fr", sm: "repeat(2, 1fr)" }}
               gap={3}
             >
               {PROVIDER_REGISTRY.map((plugin) => {
@@ -38,12 +38,14 @@ export function AddProviderDialog({
                   <Box
                     key={plugin.id}
                     position="relative"
-                    borderWidth="1px"
-                    borderColor="border.subtle"
+                    display="flex"
+                    alignItems="center"
+                    borderWidth={alreadyAdded ? "1.5px" : "1px"}
+                    borderColor={alreadyAdded ? "orange.500" : "border.subtle"}
                     borderRadius="md"
                     p={4}
                     cursor={canAdd ? "pointer" : "default"}
-                    opacity={canAdd ? 1 : 0.5}
+                    opacity={canAdd || alreadyAdded ? 1 : 0.5}
                     _hover={canAdd ? { borderColor: "border" } : undefined}
                     onClick={canAdd ? () => onAdd(plugin.id) : undefined}
                   >
@@ -58,15 +60,33 @@ export function AddProviderDialog({
                         Coming soon
                       </Badge>
                     )}
-                    <Box color="fg.muted" mb={2}>
+                    {alreadyAdded && (
+                      <Badge
+                        position="absolute"
+                        top={2}
+                        right={2}
+                        size="sm"
+                        variant="subtle"
+                        colorPalette="orange"
+                      >
+                        ✓ Configured
+                      </Badge>
+                    )}
+                    <Box
+                      color="fg.default"
+                      flexShrink={0}
+                      mr={4}
+                    >
                       <plugin.Logo width="24" height="24" />
                     </Box>
-                    <Text fontSize="sm" fontWeight="medium">
-                      {plugin.label}
-                    </Text>
-                    <Text fontSize="xs" color="fg.muted">
-                      {alreadyAdded ? "Already added" : plugin.hint}
-                    </Text>
+                    <Box>
+                      <Text fontSize="md" fontWeight="medium" color="fg.default">
+                        {plugin.label}
+                      </Text>
+                      <Text fontSize="xs" color="fg.muted">
+                        {alreadyAdded ? "Already added" : plugin.hint}
+                      </Text>
+                    </Box>
                   </Box>
                 );
               })}


### PR DESCRIPTION
# feat: update provider card layout and configured badge

## What is this PR about?

Updates the "Add Provider" dialog: horizontal card layout (logo left, text right), responsive 1–2 column grid, and an orange "✓ Configured" badge with accent border for already-added providers.

## Why is this change needed?

Fixes #36 (vertical layout was hard to scan) and #37 (no visual indicator for already-configured providers).

## How is this change implemented?

- Switched card inner layout to flexbox row with logo left, name+hint right
- Changed grid from `auto-fill minmax(180px)` to explicit `1fr` / `repeat(2, 1fr)` responsive columns
- Bumped provider name from `fontSize="sm"` to `"md"` for better hierarchy
- Added absolute-positioned `Badge` with `colorPalette="orange"` for configured providers
- Orange `1.5px` border on configured cards; full opacity (previously dimmed to 0.5)

## How to test this change?

1. Open Settings → LLM Providers
2. Click "Add Provider"
3. Confirm cards show logo on the left with name and hint to the right
4. Configure Ollama, then reopen the dialog — Ollama card should show the orange "✓ Configured" badge and border at full opacity
5. Resize browser to confirm single column on narrow widths, two columns on wider screens

## Notes

- "Coming soon" badge and dimmed opacity behaviour for unavailable providers is unchanged