### PR TITLE
fix: improve article row layout for mobile category chips (#31)

### DIFF
--- a/frontend/src/components/article/ArticleRow.tsx
+++ b/frontend/src/components/article/ArticleRow.tsx
@@ -75,30 +75,28 @@ export const ArticleRow = React.memo(React.forwardRef<HTMLDivElement, ArticleRow
     >
       {/* Read/unread toggle dot - hidden in expanded/sticky header to prevent layout shift */}
       {!isExpanded && !article.is_read && (
-        <Box>
+        <Box
+          flexShrink={0}
+          alignSelf="center"
+          px={2}
+          cursor="pointer"
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleRead(article);
+          }}
+          title="Mark as read"
+        >
           <Box
-            flexShrink={0}
-            alignSelf="center"
-            px={2}
-            cursor="pointer"
-            onClick={(e) => {
-              e.stopPropagation();
-              onToggleRead(article);
-            }}
-            title="Mark as read"
-          >
-            <Box
-              w="10px"
-              h="10px"
-              borderRadius="full"
-              bg="accent.solid"
-            />
-          </Box>
+            w="10px"
+            h="10px"
+            borderRadius="full"
+            bg="accent.solid"
+          />
         </Box>
       )}
 
       {/* Main content */}
-      <Flex flex={1} direction="column" gap={1} minW={0}>
+      <Flex flex={1} direction="column" gap={2} minW={0}>
         {/* Title - truncated */}
         <Text
           fontSize={isExpanded ? "sm" : "md"}
@@ -111,38 +109,29 @@ export const ArticleRow = React.memo(React.forwardRef<HTMLDivElement, ArticleRow
           {article.title}
         </Text>
 
-        {/* Source, date, and category tags */}
-        <Box
+        {/* Metadata + preview — collapses when row is expanded as sticky header */}
+        <Flex
+          direction="column"
+          gap={2}
           overflow="hidden"
           transition="max-height 0.2s ease, opacity 0.15s ease"
-          {...(isExpanded ? { maxH: 0, opacity: 0 } : { maxH: "10", opacity: 1 })}
+          {...(isExpanded ? { maxH: 0, opacity: 0 } : { maxH: "24", opacity: 1 })}
         >
-          <Flex gap={2} alignItems="center" flexWrap="wrap">
-            <Text fontSize="sm" color="fg.muted" flexShrink={0}>
-              {feedName ? `${feedName} \u2022 ` : ""}{formatRelativeDate(article.published_at)}
-            </Text>
-            {article.categories && article.categories.length > 0 && (
-              <>
-                <Box w="1px" h="14px" bg="border.subtle" flexShrink={0} />
-                {article.categories.slice(0, MAX_VISIBLE_TAGS).map((cat) => (
-                  <TagChip key={cat.id} label={cat.display_name} size="sm" />
-                ))}
-                {article.categories.length > MAX_VISIBLE_TAGS && (
-                  <Text fontSize="xs" color="fg.muted">
-                    +{article.categories.length - MAX_VISIBLE_TAGS}
-                  </Text>
-                )}
-              </>
-            )}
-          </Flex>
-        </Box>
-
-        {/* Summary/preview line */}
-        <Box
-          overflow="hidden"
-          transition="max-height 0.2s ease, opacity 0.15s ease"
-          {...(isExpanded ? { maxH: 0, opacity: 0 } : { maxH: "10", opacity: 1 })}
-        >
+          <Text fontSize="sm" color="fg.muted">
+            {feedName ? `${feedName} \u2022 ` : ""}{formatRelativeDate(article.published_at)}
+          </Text>
+          {article.categories && article.categories.length > 0 && (
+            <Flex gap={2} alignItems="center" flexWrap="wrap">
+              {article.categories.slice(0, MAX_VISIBLE_TAGS).map((cat) => (
+                <TagChip key={cat.id} label={cat.display_name} size="sm" />
+              ))}
+              {article.categories.length > MAX_VISIBLE_TAGS && (
+                <Text fontSize="xs" color="fg.muted">
+                  +{article.categories.length - MAX_VISIBLE_TAGS}
+                </Text>
+              )}
+            </Flex>
+          )}
           {previewText && (
             <Flex gap={1} alignItems="flex-start">
               {isAiGenerated && (
@@ -164,7 +153,7 @@ export const ArticleRow = React.memo(React.forwardRef<HTMLDivElement, ArticleRow
               </Text>
             </Flex>
           )}
-        </Box>
+        </Flex>
       </Flex>
 
       {/* Right side: scoring indicators or expanded nav */}

--- a/frontend/src/components/article/TagChip.tsx
+++ b/frontend/src/components/article/TagChip.tsx
@@ -50,6 +50,8 @@ export function TagChip({
       py={0.5}
       borderRadius="md"
       fontWeight="medium"
+      maxW="40"
+      truncate
       {...colorProps}
       cursor={interactive ? "pointer" : "default"}
       _hover={interactive ? { opacity: 0.8 } : undefined}


### PR DESCRIPTION
## What is this PR about?

Category chips on article rows were being clipped on mobile viewports due to a 40px `max-height` constraint on the metadata container. Chips are now rendered on their own dedicated line below the source/date text.

## Why is this change needed?

On narrow screens, chips wrapped to a second line but were hidden by the height cap, making them invisible to the user (GH #31).

## How is this change implemented?

- Chips moved to their own row beneath source/date text (always, on all screen sizes)
- Two animation wrappers merged into one collapsible `Flex`, reducing DOM nesting
- `maxH` increased from theme token `"10"` (40px) to `"24"` (96px) to accommodate wrapped content
- `maxW="40"` + `truncate` added to `TagChip` as a safety net for very long category names
- Row spacing increased from `gap={1}` to `gap={2}` throughout for better readability

## How to test this change?

1. Open the app and navigate to the article list
2. In Chrome DevTools, enable mobile emulation (e.g. iPhone 14, 390px wide)
3. Find articles with category chips — confirm all chips are fully visible on their own line
4. Click an article to open it — confirm the metadata row collapses smoothly
5. On desktop, confirm the layout looks correct at normal widths too

## Notes

- The collapse animation still works; `max-height` transitions require a concrete value (not `auto`), so `"24"` was chosen as a theme-conforming token that fits all realistic content.