### PR TITLE
fix: prevent nested <a> tags in article content (#41)

### DIFF
--- a/frontend/src/components/article/ArticleContent.tsx
+++ b/frontend/src/components/article/ArticleContent.tsx
@@ -20,20 +20,29 @@ const parserOptions: HTMLReactParserOptions = {
     if (domNode.name === "img") {
       const src = domNode.attribs.src;
       const alt = domNode.attribs.alt || "";
+      const parentIsLink =
+        domNode.parent instanceof Element && domNode.parent.name === "a";
+
+      const img = (
+        <img
+          src={src}
+          alt={alt}
+          loading="lazy"
+          style={{
+            maxWidth: "100%",
+            height: "auto",
+            borderRadius: "8px",
+            marginTop: "1rem",
+            marginBottom: "1rem",
+          }}
+        />
+      );
+
+      if (parentIsLink) return img;
+
       return (
         <a href={src} target="_blank" rel="noopener noreferrer">
-          <img
-            src={src}
-            alt={alt}
-            loading="lazy"
-            style={{
-              maxWidth: "100%",
-              height: "auto",
-              borderRadius: "8px",
-              marginTop: "1rem",
-              marginBottom: "1rem",
-            }}
-          />
+          {img}
         </a>
       );
     }


### PR DESCRIPTION
## What is this PR about?

Fixes a React hydration error caused by nested `<a>` tags when RSS feeds contain linked images (`<a><img/></a>`).

## Why is this change needed?

The `ArticleContent` parser had two `replace` handlers: one wrapping every `<img>` in an `<a>` and one re-rendering every `<a>`. Together they produced `<a><a><img/></a></a>` — invalid HTML that caused hydration mismatches in the article list view.

## How is this change implemented?

- In the `img` handler in `ArticleContent.tsx`, check if `domNode.parent` is already an `<a>` element.
- If so, return the styled `<img>` directly without wrapping it in another anchor.
- Standalone images (not inside a link) still get click-to-open-in-new-tab behavior unchanged.

## How to test this change?

1. Open the app and navigate to a feed that includes linked images (e.g. Feber).
2. Open an article — confirm no console errors about nested `<a>` tags and no hydration warnings.
3. Click a standalone image — confirm it opens in a new tab.
4. Click a linked image — confirm it follows the article link, not the image URL.

## Notes

- Pre-existing lint errors are unrelated to this change.