### PR TITLE
feat: add Test Connection button to Ollama config (#35)

### DIFF
--- a/backend/src/backend/ollama_service.py
+++ b/backend/src/backend/ollama_service.py
@@ -47,7 +47,7 @@ async def check_health(host: str) -> dict:
                 "version": data.get("version"),
                 "latency_ms": latency_ms,
             }
-    except httpx.HTTPError, httpx.TimeoutException, ConnectionError, OSError:
+    except (httpx.HTTPError, httpx.TimeoutException, ConnectionError, OSError):
         return {"connected": False, "version": None, "latency_ms": None}
 
 

--- a/backend/src/backend/routers/ollama.py
+++ b/backend/src/backend/routers/ollama.py
@@ -92,6 +92,11 @@ class OllamaHealthResponse(BaseModel):
     latency_ms: int | None
 
 
+class TestConnectionRequest(BaseModel):
+    base_url: str
+    port: int = Field(ge=1, le=65535)
+
+
 class OllamaModelResponse(BaseModel):
     name: str
     size: int
@@ -289,6 +294,14 @@ async def ollama_health(session: Session = Depends(get_session)):
     config = get_ollama_provider_config(session)
     provider = get_provider("ollama")
     result = await provider.health(config.endpoint)
+    return OllamaHealthResponse(**result)
+
+
+@router.post("/ollama/test-connection", response_model=OllamaHealthResponse)
+async def test_ollama_connection(request: TestConnectionRequest):
+    """Test Ollama connectivity with arbitrary host/port (no DB dependency)."""
+    endpoint = f"{request.base_url}:{request.port}"
+    result = await ollama_service.check_health(endpoint)
     return OllamaHealthResponse(**result)
 
 

--- a/backend/tests/test_ollama_config_router.py
+++ b/backend/tests/test_ollama_config_router.py
@@ -61,6 +61,28 @@ def test_update_ollama_config_persists_provider_config_and_routes(
     assert task_routes[1].model == "qwen3:8b"
 
 
+def test_test_connection_returns_health_response_shape(test_client: TestClient):
+    """POST /api/ollama/test-connection returns correct response shape."""
+    response = test_client.post(
+        "/api/ollama/test-connection",
+        json={"base_url": "http://localhost", "port": 11434},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "connected" in data
+    assert "version" in data
+    assert "latency_ms" in data
+
+
+def test_test_connection_rejects_invalid_port(test_client: TestClient):
+    """POST /api/ollama/test-connection rejects port outside 1-65535."""
+    response = test_client.post(
+        "/api/ollama/test-connection",
+        json={"base_url": "http://localhost", "port": 0},
+    )
+    assert response.status_code == 422
+
+
 def test_scoring_status_exposes_task_readiness_keys(test_client: TestClient):
     response = test_client.get("/api/scoring/status")
     assert response.status_code == 200

--- a/frontend/src/components/settings/providers/ollama/OllamaProviderPanel.tsx
+++ b/frontend/src/components/settings/providers/ollama/OllamaProviderPanel.tsx
@@ -9,13 +9,16 @@ import {
   Stack,
   Text,
 } from "@chakra-ui/react";
-import { useQueryClient } from "@tanstack/react-query";
+import { keyframes } from "@emotion/react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { LuCheck } from "react-icons/lu";
 import {
   useOllamaHealth,
   useOllamaModels,
   useOllamaConfig,
   useOllamaModelPull,
 } from "@/hooks/providers/ollama";
+import { testOllamaConnection } from "@/lib/api";
 import { toaster } from "@/components/ui/toaster";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { SettingsPanel } from "@/components/settings/SettingsPanel";
@@ -28,6 +31,12 @@ import type { ProviderPanelProps } from "../types";
 
 const DEFAULT_HOST = "http://localhost";
 const DEFAULT_PORT = 11434;
+
+const checkReveal = keyframes`
+  0% { opacity: 0; transform: scale(0.5); }
+  50% { opacity: 1; transform: scale(1.15); }
+  100% { opacity: 1; transform: scale(1); }
+`;
 
 export function OllamaProviderPanel({
   onDisconnect,
@@ -49,6 +58,35 @@ export function OllamaProviderPanel({
     isNew ? DEFAULT_PORT : (serverConfig?.port ?? DEFAULT_PORT)
   );
   const [showDisconnectDialog, setShowDisconnectDialog] = useState(false);
+  const [showCheck, setShowCheck] = useState(false);
+
+  const testMutation = useMutation({
+    mutationFn: () => testOllamaConnection(localHost, localPort),
+    meta: { handlesOwnErrors: true },
+    onSuccess: (data) => {
+      if (data.connected) {
+        setShowCheck(true);
+        toaster.create({
+          title: `Connection successful (v${data.version}, ${data.latency_ms}ms)`,
+          type: "success",
+        });
+        setTimeout(() => setShowCheck(false), 2000);
+      } else {
+        toaster.create({
+          title: "Connection failed",
+          description: `Could not reach Ollama at ${localHost}:${localPort}`,
+          type: "error",
+        });
+      }
+    },
+    onError: (error) => {
+      toaster.create({
+        title: "Connection test failed",
+        description: error instanceof Error ? error.message : "Unexpected error",
+        type: "error",
+      });
+    },
+  });
 
   // Sync local state when server config loads (useState initializer misses async data)
   useEffect(() => {
@@ -124,7 +162,7 @@ export function OllamaProviderPanel({
       )}
       {isNew && (
         <Text fontSize="sm" color="fg.muted" mb={4}>
-          Not connected -- save to test connection
+          Not connected -- use &ldquo;Test Connection&rdquo; or save to connect
         </Text>
       )}
 
@@ -183,6 +221,21 @@ export function OllamaProviderPanel({
             >
               Save
             </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => testMutation.mutate()}
+              loading={testMutation.isPending}
+              disabled={hostEmpty || !!hostError}
+            >
+              {showCheck ? (
+                <Box as="span" color="green.400" css={{ animation: `${checkReveal} 0.3s ease-out` }}>
+                  <LuCheck />
+                </Box>
+              ) : (
+                "Test Connection"
+              )}
+            </Button>
             <Button size="sm" variant="ghost" onClick={onCancelSetup}>
               Cancel
             </Button>
@@ -197,6 +250,21 @@ export function OllamaProviderPanel({
               disabled={!isDirty || hostEmpty || !!hostError}
             >
               Save
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => testMutation.mutate()}
+              loading={testMutation.isPending}
+              disabled={hostEmpty || !!hostError}
+            >
+              {showCheck ? (
+                <Box as="span" color="green.400" css={{ animation: `${checkReveal} 0.3s ease-out` }}>
+                  <LuCheck />
+                </Box>
+              ) : (
+                "Test Connection"
+              )}
             </Button>
             <Button
               size="sm"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -482,6 +482,23 @@ export async function saveTaskRoutes(
 
 // --- Ollama Configuration API ---
 
+export async function testOllamaConnection(
+  baseUrl: string,
+  port: number
+): Promise<OllamaHealth> {
+  const response = await fetch(`${API_BASE_URL}/api/ollama/test-connection`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ base_url: baseUrl, port }),
+  });
+
+  if (!response.ok) {
+    await throwApiError(response, "Failed to test connection");
+  }
+
+  return response.json();
+}
+
 export async function fetchOllamaHealth(): Promise<OllamaHealth> {
   const response = await fetch(`${API_BASE_URL}/api/ollama/health`);
 


### PR DESCRIPTION
## What is this PR about?

Adds a "Test Connection" button to the Ollama provider configuration panel, allowing users to verify connectivity with unsaved host/port values before saving.

## Why is this change needed?

Users had no way to validate their Ollama settings worked before committing the config — the existing health badge only reflects the saved configuration.

## How is this change implemented?

- New `POST /api/ollama/test-connection` backend endpoint that accepts arbitrary `base_url`/`port` and pings Ollama without touching the DB
- `testOllamaConnection()` fetch function added to `lib/api.ts`
- Test Connection button added between Save and Cancel/Disconnect in both new-setup and edit modes, with loading spinner, animated green checkmark on success, and error toasts on failure
- Fixed a pre-existing Python 3 `except` clause bug in `ollama_service.check_health` (comma-separated exception types instead of a tuple)

## How to test this change?

1. Go to Settings → LLM Providers → Add Ollama (or open the existing Ollama panel)
2. Enter a valid host/port for a running Ollama instance and click "Test Connection" — expect a green checkmark and success toast
3. Enter an invalid host/port and click "Test Connection" — expect a red error toast
4. Confirm Save still works independently after a failed test

## Notes

- Closes #35
- Also created #46 to track moving Ollama-specific fetch functions from `lib/api.ts` to a provider-scoped module (future cleanup when a second provider is added)