### PR TITLE
feat: mobile floating action bar for article list controls

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -12,6 +12,7 @@
 
 # testing
 /coverage
+/test-results
 
 # next.js
 /.next/

--- a/frontend/src/components/article/ArticleList.tsx
+++ b/frontend/src/components/article/ArticleList.tsx
@@ -10,6 +10,7 @@ import React, {
 import NextLink from "next/link";
 import {
   Alert,
+  Badge,
   Box,
   createListCollection,
   Flex,
@@ -49,7 +50,8 @@ import { ArticleRowSkeleton } from "./ArticleRowSkeleton";
 import { ArticleReader } from "./ArticleReader";
 import { SortSelect } from "./SortSelect";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
-import { ArticleListItem, FeedSelection } from "@/lib/types";
+import { MobileArticleActionBar } from "./MobileArticleActionBar";
+import { ArticleListItem, FeedSelection, FilterTab } from "@/lib/types";
 import { parseSortOption } from "@/lib/utils";
 
 interface ArticleListProps {
@@ -57,8 +59,6 @@ interface ArticleListProps {
   onOpenMobileSidebar?: () => void;
   mainRef: React.RefObject<HTMLDivElement | null>;
 }
-
-type FilterTab = "unread" | "all" | "scoring" | "blocked";
 
 export function ArticleList({
   selection,
@@ -155,6 +155,14 @@ export function ArticleList({
         ? (folders?.find((folder) => folder.id === selection.folderId)?.name ??
           "Folder")
         : "Articles";
+
+  // Unread count for heading badge
+  const unreadCount =
+    selection.kind === "feed"
+      ? (feeds?.find((f) => f.id === selection.feedId)?.unread_count ?? 0)
+      : selection.kind === "folder"
+        ? (folders?.find((f) => f.id === selection.folderId)?.unread_count ?? 0)
+        : (feeds?.reduce((sum, f) => sum + f.unread_count, 0) ?? 0);
 
   // IntersectionObserver for sticky scroll-collapse
   useEffect(() => {
@@ -321,7 +329,7 @@ export function ArticleList({
           : LuBan;
 
   return (
-    <Box>
+    <Box pb={{ base: 16, md: 0 }}>
       {/* Scoring readiness warning */}
       {scoringStatus?.scoring_ready === false &&
         scoringStatus.scoring_ready_reason && (
@@ -364,10 +372,17 @@ export function ArticleList({
         <Heading ref={headingRef} fontSize='2xl' fontWeight='bold'>
           {feedName}
         </Heading>
+        <Box flex={1} />
+        {unreadCount > 0 && (
+          <Badge colorPalette='accent' variant='solid' size='sm'>
+            {unreadCount}
+          </Badge>
+        )}
       </Flex>
 
-      {/* Controls bar */}
+      {/* Controls bar (desktop only) */}
       <Flex
+        display={{ base: "none", md: "flex" }}
         px={4}
         py={2}
         borderBottom='1px solid'
@@ -576,6 +591,19 @@ export function ArticleList({
           )}
         </Flex>
       )}
+
+      {/* Mobile action bar */}
+      <MobileArticleActionBar
+        filter={filter}
+        onFilterChange={setFilter}
+        sortOption={sortOption}
+        onSortChange={setSortOption}
+        onMarkAllRead={handleMarkAllAsRead}
+        canMarkAllRead={filter === "unread" && articleCount > 0}
+        isMarkingRead={markAllRead.isPending || markAllArticlesRead.isPending}
+        scoringCount={scoringCount}
+        blockedCount={blockedCount}
+      />
 
       {/* Confirm mark all articles read dialog */}
       <ConfirmDialog

--- a/frontend/src/components/article/MobileArticleActionBar.test.tsx
+++ b/frontend/src/components/article/MobileArticleActionBar.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders, userEvent } from "@/test/utils";
+import { MobileArticleActionBar } from "./MobileArticleActionBar";
+
+const defaultProps = {
+  filter: "unread" as const,
+  onFilterChange: vi.fn(),
+  sortOption: "score_desc" as const,
+  onSortChange: vi.fn(),
+  onMarkAllRead: vi.fn(),
+  canMarkAllRead: true,
+  isMarkingRead: false,
+  scoringCount: 0,
+  blockedCount: 0,
+};
+
+describe("MobileArticleActionBar", () => {
+  it("renders mark-all-read button when canMarkAllRead is true", () => {
+    renderWithProviders(<MobileArticleActionBar {...defaultProps} />);
+    expect(
+      screen.getByRole("button", { name: /mark all as read/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides mark-all-read button when canMarkAllRead is false", () => {
+    renderWithProviders(
+      <MobileArticleActionBar {...defaultProps} canMarkAllRead={false} />,
+    );
+    expect(
+      screen.queryByRole("button", { name: /mark all as read/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("calls onMarkAllRead when mark-all-read button is clicked", async () => {
+    const onMarkAllRead = vi.fn();
+    renderWithProviders(
+      <MobileArticleActionBar
+        {...defaultProps}
+        onMarkAllRead={onMarkAllRead}
+      />,
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /mark all as read/i }));
+    expect(onMarkAllRead).toHaveBeenCalledOnce();
+  });
+
+  it("disables mark-all-read button when isMarkingRead is true", () => {
+    renderWithProviders(
+      <MobileArticleActionBar {...defaultProps} isMarkingRead={true} />,
+    );
+    expect(
+      screen.getByRole("button", { name: /mark all as read/i }),
+    ).toBeDisabled();
+  });
+
+  it("renders filter trigger showing current filter label", () => {
+    renderWithProviders(
+      <MobileArticleActionBar {...defaultProps} filter="scoring" />,
+    );
+    expect(screen.getByRole("button", { name: /scoring/i })).toBeInTheDocument();
+  });
+
+  it("renders sort trigger showing current sort label", () => {
+    renderWithProviders(
+      <MobileArticleActionBar {...defaultProps} sortOption="date_desc" />,
+    );
+    expect(
+      screen.getByRole("button", { name: /newest/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/article/MobileArticleActionBar.tsx
+++ b/frontend/src/components/article/MobileArticleActionBar.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useState } from "react";
+import {
+  ActionBar,
+  Button,
+  Flex,
+  IconButton,
+  Popover,
+  Portal,
+  SegmentGroup,
+  Stack,
+  Text,
+} from "@chakra-ui/react";
+import {
+  LuArrowDownWideNarrow,
+  LuArrowUpDown,
+  LuArrowUpNarrowWide,
+  LuCheckCheck,
+  LuFilter,
+} from "react-icons/lu";
+import type { FilterTab, SortOption } from "@/lib/types";
+
+interface MobileArticleActionBarProps {
+  filter: FilterTab;
+  onFilterChange: (filter: FilterTab) => void;
+  sortOption: SortOption;
+  onSortChange: (sort: SortOption) => void;
+  onMarkAllRead: () => void;
+  canMarkAllRead: boolean;
+  isMarkingRead: boolean;
+  scoringCount: number;
+  blockedCount: number;
+}
+
+const filterLabels: Record<FilterTab, string> = {
+  unread: "Unread",
+  all: "All",
+  scoring: "Scoring",
+  blocked: "Blocked",
+};
+
+const sortLabels: Record<SortOption, string> = {
+  score_desc: "Highest score",
+  score_asc: "Lowest score",
+  date_desc: "Newest first",
+  date_asc: "Oldest first",
+};
+
+export function MobileArticleActionBar({
+  filter,
+  onFilterChange,
+  sortOption,
+  onSortChange,
+  onMarkAllRead,
+  canMarkAllRead,
+  isMarkingRead,
+  scoringCount,
+  blockedCount,
+}: MobileArticleActionBarProps) {
+  const [filterOpen, setFilterOpen] = useState(false);
+  const [sortOpen, setSortOpen] = useState(false);
+
+  return (
+    <ActionBar.Root open={true} closeOnInteractOutside={false}>
+      <Portal>
+        <ActionBar.Positioner display={{ base: "block", md: "none" }} px={4}>
+          <ActionBar.Content borderRadius="full">
+            {canMarkAllRead && (
+              <>
+                <IconButton
+                  aria-label="Mark all as read"
+                  size="sm"
+                  variant="ghost"
+                  onClick={onMarkAllRead}
+                  disabled={isMarkingRead}
+                >
+                  <LuCheckCheck />
+                </IconButton>
+                <ActionBar.Separator />
+              </>
+            )}
+
+            {/* Filter popover */}
+            <Popover.Root
+              positioning={{ placement: "top" }}
+              open={filterOpen}
+              onOpenChange={(e) => setFilterOpen(e.open)}
+            >
+              <Popover.Trigger asChild>
+                <Button variant="ghost" size="sm" aria-label={filterLabels[filter]}>
+                  <LuFilter />
+                  {filterLabels[filter]}
+                </Button>
+              </Popover.Trigger>
+              <Portal>
+                <Popover.Positioner>
+                  <Popover.Content width="auto">
+                    <Popover.Body p={2}>
+                      <SegmentGroup.Root
+                        size="sm"
+                        value={filter}
+                        onValueChange={(e) =>
+                          onFilterChange(e.value as FilterTab)
+                        }
+                        onClick={() => setFilterOpen(false)}
+                      >
+                        <SegmentGroup.Indicator />
+                        <SegmentGroup.Item value="unread">
+                          <SegmentGroup.ItemText>Unread</SegmentGroup.ItemText>
+                          <SegmentGroup.ItemHiddenInput />
+                        </SegmentGroup.Item>
+                        <SegmentGroup.Item value="all">
+                          <SegmentGroup.ItemText>All</SegmentGroup.ItemText>
+                          <SegmentGroup.ItemHiddenInput />
+                        </SegmentGroup.Item>
+                        <SegmentGroup.Item
+                          value="scoring"
+                          disabled={scoringCount === 0}
+                        >
+                          <SegmentGroup.ItemText>
+                            Scoring{scoringCount > 0 ? ` (${scoringCount})` : ""}
+                          </SegmentGroup.ItemText>
+                          <SegmentGroup.ItemHiddenInput />
+                        </SegmentGroup.Item>
+                        <SegmentGroup.Item
+                          value="blocked"
+                          disabled={blockedCount === 0}
+                        >
+                          <SegmentGroup.ItemText>
+                            Blocked{blockedCount > 0 ? ` (${blockedCount})` : ""}
+                          </SegmentGroup.ItemText>
+                          <SegmentGroup.ItemHiddenInput />
+                        </SegmentGroup.Item>
+                      </SegmentGroup.Root>
+                    </Popover.Body>
+                  </Popover.Content>
+                </Popover.Positioner>
+              </Portal>
+            </Popover.Root>
+
+            <ActionBar.Separator />
+
+            {/* Sort popover */}
+            <Popover.Root
+              positioning={{ placement: "top" }}
+              open={sortOpen}
+              onOpenChange={(e) => setSortOpen(e.open)}
+              lazyMount
+              unmountOnExit
+            >
+              <Popover.Trigger asChild>
+                <Button variant="ghost" size="sm" aria-label={sortLabels[sortOption]}>
+                  <LuArrowUpDown />
+                  {sortLabels[sortOption]}
+                </Button>
+              </Popover.Trigger>
+              <Portal>
+                <Popover.Positioner>
+                  <Popover.Content minW="64">
+                    <Popover.Body p={3}>
+                      <Stack gap={2}>
+                        <Text fontSize="xs" fontWeight="medium" color="fg.muted">
+                          By score
+                        </Text>
+                        <SegmentGroup.Root
+                          size="sm"
+                          value={
+                            sortOption === "score_desc" ||
+                            sortOption === "score_asc"
+                              ? sortOption
+                              : ""
+                          }
+                          onValueChange={(e) =>
+                            onSortChange(e.value as SortOption)
+                          }
+                          onClick={() => setSortOpen(false)}
+                        >
+                          <SegmentGroup.Indicator />
+                          <SegmentGroup.Item value="score_desc" flex={1}>
+                            <SegmentGroup.ItemText>
+                              <Flex align="center" gap={1}>
+                                <LuArrowDownWideNarrow /> Highest
+                              </Flex>
+                            </SegmentGroup.ItemText>
+                            <SegmentGroup.ItemHiddenInput />
+                          </SegmentGroup.Item>
+                          <SegmentGroup.Item value="score_asc" flex={1}>
+                            <SegmentGroup.ItemText>
+                              <Flex align="center" gap={1}>
+                                <LuArrowUpNarrowWide /> Lowest
+                              </Flex>
+                            </SegmentGroup.ItemText>
+                            <SegmentGroup.ItemHiddenInput />
+                          </SegmentGroup.Item>
+                        </SegmentGroup.Root>
+
+                        <Text fontSize="xs" fontWeight="medium" color="fg.muted">
+                          By date
+                        </Text>
+                        <SegmentGroup.Root
+                          size="sm"
+                          value={
+                            sortOption === "date_desc" ||
+                            sortOption === "date_asc"
+                              ? sortOption
+                              : ""
+                          }
+                          onValueChange={(e) =>
+                            onSortChange(e.value as SortOption)
+                          }
+                          onClick={() => setSortOpen(false)}
+                        >
+                          <SegmentGroup.Indicator />
+                          <SegmentGroup.Item value="date_desc" flex={1}>
+                            <SegmentGroup.ItemText>
+                              <Flex align="center" gap={1}>
+                                <LuArrowDownWideNarrow /> Newest
+                              </Flex>
+                            </SegmentGroup.ItemText>
+                            <SegmentGroup.ItemHiddenInput />
+                          </SegmentGroup.Item>
+                          <SegmentGroup.Item value="date_asc" flex={1}>
+                            <SegmentGroup.ItemText>
+                              <Flex align="center" gap={1}>
+                                <LuArrowUpNarrowWide /> Oldest
+                              </Flex>
+                            </SegmentGroup.ItemText>
+                            <SegmentGroup.ItemHiddenInput />
+                          </SegmentGroup.Item>
+                        </SegmentGroup.Root>
+                      </Stack>
+                    </Popover.Body>
+                  </Popover.Content>
+                </Popover.Positioner>
+              </Portal>
+            </Popover.Root>
+          </ActionBar.Content>
+        </ActionBar.Positioner>
+      </Portal>
+    </ActionBar.Root>
+  );
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -167,6 +167,8 @@ export type TimeUnit = "seconds" | "minutes" | "hours";
 
 export type SortOption = "score_desc" | "score_asc" | "date_desc" | "date_asc";
 
+export type FilterTab = "unread" | "all" | "scoring" | "blocked";
+
 export interface ScoringStatus {
   unscored: number;
   queued: number;


### PR DESCRIPTION
## What is this PR about?

Moves filter, sort, and mark-all-read controls to a floating pill-shaped bottom action bar on mobile, leaving the sticky header cleaner with just the hamburger, feed title, and a new unread count badge.

## Why is this change needed?

The sticky header was crowded on small screens. This improves mobile usability by relocating controls to a thumb-friendly bottom bar while keeping the desktop layout completely unchanged.

## How is this change implemented?

- New `MobileArticleActionBar` component: Chakra `ActionBar` with two `Popover`-based pickers — filter (single SegmentGroup) and sort (two stacked SegmentGroups for "By score" / "By date" with directional icons)
- `ArticleList`: controls bar hidden on mobile (`display={{ base: "none", md: "flex" }}`), unread count badge added to heading row, bottom padding added so last articles aren't hidden behind the bar
- `FilterTab` type extracted to `lib/types.ts` and exported

## How to test this change?

1. Open the app in a mobile-width browser (≤ 768px)
2. Confirm a pill-shaped bar appears at the bottom with Filter and Sort buttons
3. Tap Filter — a segmented control opens above with Unread / All / Scoring / Blocked
4. Tap Sort — two segmented rows open above: "By score" (Highest/Lowest) and "By date" (Newest/Oldest)
5. Confirm changing either updates the article list
6. On desktop (≥ 768px), confirm the bottom bar is gone and the original controls bar is unchanged

Closes #49