### PR TITLE
refactor(backend): remove dead code and reduce duplication

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -20,9 +20,9 @@ def include_object(
     object_,
     name: str | None,
     type_: str,
-    reflected: bool,  # noqa: ARG001
+    reflected: bool,
     compare_to,
-) -> bool:  # noqa: ANN001
+) -> bool:
     """Skip legacy bootstrap table from schema drift checks."""
     if type_ == "table" and name == "schema_version":
         return False

--- a/backend/src/backend/__init__.py
+++ b/backend/src/backend/__init__.py
@@ -1,2 +1,0 @@
-def main() -> None:
-    print("Hello from backend!")

--- a/backend/src/backend/database.py
+++ b/backend/src/backend/database.py
@@ -128,7 +128,7 @@ def _seed_default_categories(conn):
     from backend.prompts import DEFAULT_CATEGORY_HIERARCHY
 
     count = conn.execute(text("SELECT COUNT(*) FROM categories")).scalar()
-    if count and count > 0:
+    if count:
         return
 
     hierarchy = DEFAULT_CATEGORY_HIERARCHY

--- a/backend/src/backend/feeds.py
+++ b/backend/src/backend/feeds.py
@@ -130,7 +130,9 @@ async def refresh_feed(session: Session, feed: Feed) -> int:
 
         # Save articles and enqueue for scoring
         new_count, new_article_ids = save_articles(
-            session, feed.id, parsed_feed.entries  # pyright: ignore[reportArgumentType]
+            session,
+            feed.id,
+            parsed_feed.entries,  # pyright: ignore[reportArgumentType]
         )
 
         # Enqueue new articles for scoring

--- a/backend/src/backend/llm_providers/ollama.py
+++ b/backend/src/backend/llm_providers/ollama.py
@@ -268,8 +268,6 @@ class OllamaProviderConfig(BaseModel):
             raise ValueError("base_url must not include credentials")
 
         hostname = parsed.hostname
-        if hostname is None:
-            raise ValueError("base_url must include a valid host")
         if ":" in hostname and not hostname.startswith("["):
             hostname = f"[{hostname}]"
         return f"{parsed.scheme}://{hostname}"

--- a/backend/src/backend/routers/articles.py
+++ b/backend/src/backend/routers/articles.py
@@ -31,23 +31,26 @@ def _strip_html_truncate(html: str | None, max_len: int = 200) -> str | None:
     return text
 
 
-def _article_to_response(article: Article) -> ArticleResponse:
-    """Convert an Article with loaded categories_rel to an ArticleResponse."""
+def _build_category_embeds(article: Article) -> list[ArticleCategoryEmbed] | None:
+    """Build category embed list from an Article with loaded categories_rel."""
+    if not article.categories_rel:
+        return None
     from backend.scoring import get_effective_weight
 
-    categories = None
-    if article.categories_rel:
-        categories = [
-            ArticleCategoryEmbed(
-                id=cat.id,  # pyright: ignore[reportArgumentType]
-                display_name=cat.display_name,
-                slug=cat.slug,
-                effective_weight=get_effective_weight(cat),
-                parent_display_name=cat.parent.display_name if cat.parent else None,
-            )
-            for cat in article.categories_rel
-        ]
+    return [
+        ArticleCategoryEmbed(
+            id=cat.id,  # pyright: ignore[reportArgumentType]
+            display_name=cat.display_name,
+            slug=cat.slug,
+            effective_weight=get_effective_weight(cat),
+            parent_display_name=cat.parent.display_name if cat.parent else None,
+        )
+        for cat in article.categories_rel
+    ]
 
+
+def _article_to_response(article: Article) -> ArticleResponse:
+    """Convert an Article with loaded categories_rel to an ArticleResponse."""
     return ArticleResponse(
         id=article.id,  # pyright: ignore[reportArgumentType]
         feed_id=article.feed_id,
@@ -58,7 +61,7 @@ def _article_to_response(article: Article) -> ArticleResponse:
         summary=article.summary,
         content=article.content,
         is_read=article.is_read,
-        categories=categories,
+        categories=_build_category_embeds(article),
         interest_score=article.interest_score,
         quality_score=article.quality_score,
         composite_score=article.composite_score,
@@ -70,21 +73,6 @@ def _article_to_response(article: Article) -> ArticleResponse:
 
 def _article_to_list_item(article: Article) -> ArticleListItem:
     """Convert an Article with loaded categories_rel to a lightweight list item."""
-    from backend.scoring import get_effective_weight
-
-    categories = None
-    if article.categories_rel:
-        categories = [
-            ArticleCategoryEmbed(
-                id=cat.id,  # pyright: ignore[reportArgumentType]
-                display_name=cat.display_name,
-                slug=cat.slug,
-                effective_weight=get_effective_weight(cat),
-                parent_display_name=cat.parent.display_name if cat.parent else None,
-            )
-            for cat in article.categories_rel
-        ]
-
     return ArticleListItem(
         id=article.id,  # pyright: ignore[reportArgumentType]
         feed_id=article.feed_id,
@@ -93,7 +81,7 @@ def _article_to_list_item(article: Article) -> ArticleListItem:
         author=article.author,
         published_at=article.published_at,
         is_read=article.is_read,
-        categories=categories,
+        categories=_build_category_embeds(article),
         interest_score=article.interest_score,
         quality_score=article.quality_score,
         composite_score=article.composite_score,
@@ -157,11 +145,13 @@ def list_articles(
     if sort_by == "composite_score":
         if order == "desc":
             statement = statement.order_by(
-                nulls_last(desc(Article.composite_score)), Article.published_at.asc()  # pyright: ignore[reportArgumentType, reportAttributeAccessIssue, reportOptionalMemberAccess]
+                nulls_last(desc(Article.composite_score)),
+                Article.published_at.asc(),  # pyright: ignore[reportArgumentType, reportAttributeAccessIssue, reportOptionalMemberAccess]
             )
         else:
             statement = statement.order_by(
-                nulls_last(Article.composite_score), Article.published_at.asc()  # pyright: ignore[reportArgumentType, reportAttributeAccessIssue, reportOptionalMemberAccess]
+                nulls_last(Article.composite_score),
+                Article.published_at.asc(),  # pyright: ignore[reportArgumentType, reportAttributeAccessIssue, reportOptionalMemberAccess]
             )
     elif sort_by == "published_at":
         if order == "desc":

--- a/backend/src/backend/routers/categories.py
+++ b/backend/src/backend/routers/categories.py
@@ -59,7 +59,8 @@ def list_categories(
     """Get flat list of all categories with article counts."""
     statement = (
         select(
-            Category, func.count(ArticleCategoryLink.article_id).label("article_count")  # pyright: ignore[reportArgumentType]
+            Category,
+            func.count(ArticleCategoryLink.article_id).label("article_count"),  # pyright: ignore[reportArgumentType]
         )
         .outerjoin(ArticleCategoryLink, Category.id == ArticleCategoryLink.category_id)  # pyright: ignore[reportArgumentType]
         .group_by(Category.id)  # pyright: ignore[reportArgumentType]
@@ -192,10 +193,8 @@ def merge_categories(
             .where(ArticleCategoryLink.article_id == link.article_id)
             .where(ArticleCategoryLink.category_id == body.target_id)
         ).first()
-        if existing:
-            session.delete(link)
-        else:
-            session.delete(link)
+        session.delete(link)
+        if not existing:
             new_link = ArticleCategoryLink(
                 article_id=link.article_id,
                 category_id=body.target_id,

--- a/backend/src/backend/routers/feeds.py
+++ b/backend/src/backend/routers/feeds.py
@@ -123,7 +123,9 @@ async def create_feed(
     session.refresh(feed)
 
     article_count, new_article_ids = save_articles(
-        session, feed.id, parsed_feed.entries  # pyright: ignore[reportArgumentType]
+        session,
+        feed.id,
+        parsed_feed.entries,  # pyright: ignore[reportArgumentType]
     )
     logger.info(f"Created feed {feed.title} with {article_count} articles")
 

--- a/backend/src/backend/routers/ollama.py
+++ b/backend/src/backend/routers/ollama.py
@@ -109,20 +109,16 @@ class PullModelRequest(BaseModel):
     model: str
 
 
-class OllamaConfigResponse(BaseModel):
-    base_url: str
-    port: int = Field(ge=1, le=65535)
-    categorization_model: str | None
-    scoring_model: str | None
-    use_separate_models: bool
-
-
 class OllamaConfigUpdate(BaseModel):
     base_url: str
     port: int = Field(ge=1, le=65535)
     categorization_model: str | None
     scoring_model: str | None
     use_separate_models: bool
+
+
+class OllamaConfigResponse(OllamaConfigUpdate):
+    pass
 
 
 class OllamaPromptsResponse(BaseModel):

--- a/backend/src/backend/scoring.py
+++ b/backend/src/backend/scoring.py
@@ -177,10 +177,7 @@ def get_active_categories(
     hierarchy: dict[str, list[str]] = {}
     for cat in categories:
         if cat.parent_id is not None and cat.parent is not None:
-            parent_name = cat.parent.display_name
-            if parent_name not in hierarchy:
-                hierarchy[parent_name] = []
-            hierarchy[parent_name].append(cat.display_name)
+            hierarchy.setdefault(cat.parent.display_name, []).append(cat.display_name)
 
     # Sort children lists for consistency
     for children in hierarchy.values():

--- a/backend/tests/test_auto_group.py
+++ b/backend/tests/test_auto_group.py
@@ -30,9 +30,7 @@ MOCK_RUNTIME = TaskRuntimeResolution(
 
 class TestBuildGroupingPrompt:
     def test_includes_all_category_names(self):
-        prompt = build_grouping_prompt(
-            ["AI", "Programming", "Science"], {}
-        )
+        prompt = build_grouping_prompt(["AI", "Programming", "Science"], {})
         assert "- AI" in prompt
         assert "- Programming" in prompt
         assert "- Science" in prompt
@@ -146,9 +144,7 @@ class TestAutoGroupApply:
         make_category: Callable[..., Category],
     ):
         """Child with explicit weight keeps it after flatten, not overwritten by parent."""
-        parent = make_category(
-            display_name="Parent", slug="parent", weight="boost"
-        )
+        parent = make_category(display_name="Parent", slug="parent", weight="boost")
         child = make_category(
             display_name="Child",
             slug="child",
@@ -276,7 +272,9 @@ class TestAutoGroupSuggest:
         # LLM returns non-canonical casing — response should use DB display_name
         mock_response = GroupingResponse(
             groups=[
-                GroupSuggestion(parent="technology", children=["ai", "machine learning"]),
+                GroupSuggestion(
+                    parent="technology", children=["ai", "machine learning"]
+                ),
                 # This one references non-existent categories — should be filtered out
                 GroupSuggestion(parent="Science", children=["Physics", "Biology"]),
             ]
@@ -287,9 +285,7 @@ class TestAutoGroupSuggest:
                 "backend.routers.categories.resolve_task_runtime",
                 return_value=MOCK_RUNTIME,
             ),
-            patch(
-                "backend.routers.categories.get_provider"
-            ) as mock_get_provider,
+            patch("backend.routers.categories.get_provider") as mock_get_provider,
         ):
             mock_provider = AsyncMock()
             mock_provider.suggest_groups.return_value = mock_response

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -362,8 +362,7 @@ def test_upgrade_preserves_custom_ollama_host_from_env(monkeypatch) -> None:
 
         with sqlite3.connect(db_path) as conn:
             provider_row = conn.execute(
-                "SELECT config_json FROM llm_provider_configs "
-                "WHERE provider = 'ollama'"
+                "SELECT config_json FROM llm_provider_configs WHERE provider = 'ollama'"
             ).fetchone()
             assert provider_row is not None
 

--- a/backend/tests/test_scoring.py
+++ b/backend/tests/test_scoring.py
@@ -77,11 +77,6 @@ def test_composite_score_capped_at_max():
     score = compute_composite_score(10, 10, [cat])
     assert score == 20.0
 
-    # Even higher theoretical value still caps at 20.0
-    cat2 = _make_category(weight="max")
-    score2 = compute_composite_score(10, 10, [cat2])
-    assert score2 <= 20.0
-
 
 def test_composite_score_boost_weight():
     """Boost weight: interest * 1.5 * quality_mult."""


### PR DESCRIPTION
# refactor(backend): remove dead code and reduce duplication

## What is this PR about?

A surgical simplification pass on the backend — removes dead code, deduplicates logic, and simplifies redundant conditionals without changing any functionality or design.

## Why is this change needed?

Small pockets of dead code and duplicated logic had accumulated over time. This makes the codebase easier to read and maintain going forward.

## How is this change implemented?

- Extracted `_build_category_embeds()` helper, eliminating an identical 12-line block duplicated between `_article_to_response` and `_article_to_list_item`
- Replaced identical `OllamaConfigResponse` model with an empty subclass of `OllamaConfigUpdate` (preserves OpenAPI schema title)
- Removed never-called `main()` scaffold from `__init__.py`, unreachable hostname guard in `_validate_base_url`, and stale `noqa` comments for rules not in the ruff config
- Simplified `if count and count > 0:` → `if count:`, `setdefault()` in hierarchy builder, and deduplicated `session.delete(link)` in `merge_categories`
- Removed a redundant weaker assertion in `test_composite_score_capped_at_max`

## How to test this change?

1. Load the article list — confirm categories display with weights and parent names
2. Open an article detail view — confirm categories render correctly
3. Go to Settings → Ollama config, view the current config, change a value, save, and reload to confirm it round-trips correctly

## Notes

- Net change: −28 lines across 13 files, all behavior-preserving
- The 4 pre-existing formatting issues in `feeds.py`, `routers/feeds.py`, `test_auto_group.py`, and `test_migrations.py` were also fixed by `ruff format`