### PR TITLE
refactor: simplify frontend — extract useSidebarData, DRY feed mutations, remove dead code

### DIFF
--- a/frontend/src/components/article/ArticleList.tsx
+++ b/frontend/src/components/article/ArticleList.tsx
@@ -256,17 +256,6 @@ export function ArticleList({
     setIsReaderOpen(false);
   }, []);
 
-  // Escape key to close the reader
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && isReaderOpen) {
-        handleCloseReader();
-      }
-    };
-    document.addEventListener("keydown", handler);
-    return () => document.removeEventListener("keydown", handler);
-  }, [isReaderOpen, handleCloseReader]);
-
   const handleExitComplete = useCallback(() => {
     // If there's a pending article to open (user clicked a different article), open it
     if (pendingOpenRef.current) {

--- a/frontend/src/components/feed/FeedRow.tsx
+++ b/frontend/src/components/feed/FeedRow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import { Box, Flex, Text, Badge, IconButton, Input } from "@chakra-ui/react";
 import { LuCheckCheck, LuFolderInput, LuGripVertical, LuTrash2 } from "react-icons/lu";
 import { useSortable } from "@dnd-kit/sortable";
@@ -36,7 +36,7 @@ export function FeedRow({
 }: FeedRowProps) {
   const [isHovered, setIsHovered] = useState(false);
   const [isRevealed, setIsRevealed] = useState(false);
-  const [longPressTimer, setLongPressTimer] = useState<NodeJS.Timeout | null>(null);
+  const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleRename = useCallback(
     (newName: string) => onRename(feed.id, newName),
@@ -77,23 +77,22 @@ export function FeedRow({
 
   // Mobile long-press for rename
   const handleTouchStart = () => {
-    const timer = setTimeout(() => {
+    longPressTimer.current = setTimeout(() => {
       startRename();
     }, 500);
-    setLongPressTimer(timer);
   };
 
   const handleTouchEnd = () => {
-    if (longPressTimer) {
-      clearTimeout(longPressTimer);
-      setLongPressTimer(null);
+    if (longPressTimer.current) {
+      clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
     }
   };
 
   const handleTouchMove = () => {
-    if (longPressTimer) {
-      clearTimeout(longPressTimer);
-      setLongPressTimer(null);
+    if (longPressTimer.current) {
+      clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
     }
   };
 

--- a/frontend/src/components/layout/MobileSidebar.tsx
+++ b/frontend/src/components/layout/MobileSidebar.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import { useLocalStorage } from "@/hooks/useLocalStorage";
 import {
   Badge,
   Box,
@@ -21,15 +19,8 @@ import {
   LuPlus,
   LuSettings,
 } from "react-icons/lu";
-import { useQuery } from "@tanstack/react-query";
 import Link from "next/link";
-import { useFeeds } from "@/hooks/useFeeds";
-import {
-  useDeleteFeed,
-  useMarkAllRead,
-  useUpdateFeed,
-} from "@/hooks/useFeedMutations";
-import { useCreateFeedFolder, useFeedFolders } from "@/hooks/useFeedFolders";
+import { useSidebarData } from "@/hooks/useSidebarData";
 import { EmptyFeedState } from "@/components/feed/EmptyFeedState";
 import { FeedRow } from "@/components/feed/FeedRow";
 import { MoveToFolderDialog } from "@/components/feed/MoveToFolderDialog";
@@ -37,18 +28,9 @@ import { DeleteFeedDialog } from "@/components/feed/DeleteFeedDialog";
 import { ThemeToggle } from "@/components/ui/color-mode";
 import {
   ALL_FEEDS_SELECTION,
-  Feed,
   FeedSelection,
   isFeedSelected,
 } from "@/lib/types";
-import { fetchNewCategoryCount } from "@/lib/api";
-import { queryKeys } from "@/lib/queryKeys";
-import { NEW_COUNT_POLL_INTERVAL } from "@/lib/constants";
-import { shouldShowFolderUnreadBadge } from "./feedSelection";
-
-type RootItem =
-  | { kind: "folder"; order: number; id: number }
-  | { kind: "feed"; order: number; id: number };
 
 interface MobileSidebarProps {
   isOpen: boolean;
@@ -67,134 +49,31 @@ export function MobileSidebar({
   onAddFeedClick,
   onAddFolderClick,
 }: MobileSidebarProps) {
-  const { data: feeds, isLoading: isFeedsLoading } = useFeeds();
-  const { data: folders, isLoading: isFoldersLoading } = useFeedFolders();
-  const deleteFeed = useDeleteFeed();
-  const markAllRead = useMarkAllRead();
-  const updateFeed = useUpdateFeed();
-  const createFolder = useCreateFeedFolder();
-
-  const [feedToDelete, setFeedToDelete] = useState<Feed | null>(null);
-  const [feedToMove, setFeedToMove] = useState<Feed | null>(null);
-  const [expandedFolders, setExpandedFolders] = useLocalStorage<
-    Record<number, boolean>
-  >("expanded-folders", {});
-
-  const { data: newCatCount } = useQuery({
-    queryKey: queryKeys.categories.newCount,
-    queryFn: fetchNewCategoryCount,
-    refetchInterval: NEW_COUNT_POLL_INTERVAL,
-  });
-  const hasNewCategories = (newCatCount?.count ?? 0) > 0;
-
-  const feedsByFolder = useMemo(() => {
-    const grouped = new Map<number, Feed[]>();
-    for (const feed of feeds ?? []) {
-      if (feed.folder_id === null) continue;
-      const list = grouped.get(feed.folder_id) ?? [];
-      list.push(feed);
-      grouped.set(feed.folder_id, list);
-    }
-
-    for (const list of grouped.values()) {
-      list.sort((a, b) => a.display_order - b.display_order || a.id - b.id);
-    }
-
-    return grouped;
-  }, [feeds]);
-
-  const ungroupedFeeds = useMemo(
-    () =>
-      (feeds ?? [])
-        .filter((feed) => feed.folder_id === null)
-        .sort((a, b) => a.display_order - b.display_order || a.id - b.id),
-    [feeds],
-  );
-
-  const orderedFolders = useMemo(
-    () =>
-      [...(folders ?? [])].sort(
-        (a, b) => a.display_order - b.display_order || a.id - b.id,
-      ),
-    [folders],
-  );
-
-  const rootItems = useMemo<RootItem[]>(() => {
-    const items: RootItem[] = [
-      ...orderedFolders.map((folder) => ({
-        kind: "folder" as const,
-        order: folder.display_order,
-        id: folder.id,
-      })),
-      ...ungroupedFeeds.map((feed) => ({
-        kind: "feed" as const,
-        order: feed.display_order,
-        id: feed.id,
-      })),
-    ];
-
-    return items.sort((a, b) => {
-      if (a.order !== b.order) return a.order - b.order;
-      if (a.kind !== b.kind) return a.kind === "folder" ? -1 : 1;
-      return a.id - b.id;
-    });
-  }, [orderedFolders, ungroupedFeeds]);
-
-  const totalUnread =
-    feeds?.reduce((sum, feed) => sum + feed.unread_count, 0) ?? 0;
-
-  const isLoading = isFeedsLoading || isFoldersLoading;
-  const hasItems = (feeds?.length ?? 0) + (folders?.length ?? 0) > 0;
+  const {
+    feedsByFolder,
+    ungroupedFeeds,
+    orderedFolders,
+    rootItems,
+    isLoading,
+    hasItems,
+    totalUnread,
+    hasNewCategories,
+    expandedFolders,
+    feedToDelete,
+    setFeedToDelete,
+    feedToMove,
+    setFeedToMove,
+    handleDeleteConfirm,
+    handleRename,
+    handleMarkAllRead,
+    handleMoveFeed,
+    handleCreateFolderAndMove,
+    toggleFolderExpanded,
+  } = useSidebarData(selection, onSelect);
 
   const handleSelect = (nextSelection: FeedSelection) => {
     onSelect(nextSelection);
     onClose();
-  };
-
-  const handleDeleteConfirm = (feedId: number) => {
-    deleteFeed.mutate(feedId);
-    if (isFeedSelected(selection, feedId)) {
-      onSelect(ALL_FEEDS_SELECTION);
-    }
-    setFeedToDelete(null);
-  };
-
-  const handleMarkAllRead = (feedId: number) => {
-    markAllRead.mutate(feedId);
-  };
-
-  const handleRename = (id: number, title: string) => {
-    updateFeed.mutate({ id, data: { title } });
-  };
-
-  const handleMoveFeed = (folderId: number | null) => {
-    if (!feedToMove) return;
-    updateFeed.mutate({
-      id: feedToMove.id,
-      data: { folder_id: folderId },
-    });
-    setFeedToMove(null);
-  };
-
-  const handleCreateFolderAndMove = async (folderName: string) => {
-    if (!feedToMove) return;
-
-    try {
-      await createFolder.mutateAsync({
-        name: folderName,
-        feedIds: [feedToMove.id],
-      });
-      setFeedToMove(null);
-    } catch {
-      // Global mutation error handling displays feedback.
-    }
-  };
-
-  const toggleFolderExpanded = (folderId: number) => {
-    setExpandedFolders((previous) => ({
-      ...previous,
-      [folderId]: !(previous[folderId] ?? true),
-    }));
   };
 
   return (
@@ -303,7 +182,7 @@ export function MobileSidebar({
                           >
                             {folder.name}
                           </Text>
-                          {shouldShowFolderUnreadBadge(folder.unread_count) ? (
+                          {folder.unread_count > 0 ? (
                             <Badge colorPalette='accent' size='sm'>
                               {folder.unread_count}
                             </Badge>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import { useLocalStorage } from "@/hooks/useLocalStorage";
 import {
   Badge,
   Box,
@@ -21,15 +19,8 @@ import {
   LuPlus,
   LuRss,
 } from "react-icons/lu";
-import { useQuery } from "@tanstack/react-query";
 import Link from "next/link";
-import { useFeeds } from "@/hooks/useFeeds";
-import {
-  useDeleteFeed,
-  useMarkAllRead,
-  useUpdateFeed,
-} from "@/hooks/useFeedMutations";
-import { useCreateFeedFolder, useFeedFolders } from "@/hooks/useFeedFolders";
+import { useSidebarData } from "@/hooks/useSidebarData";
 import { EmptyFeedState } from "@/components/feed/EmptyFeedState";
 import { FeedRow } from "@/components/feed/FeedRow";
 import { MoveToFolderDialog } from "@/components/feed/MoveToFolderDialog";
@@ -37,22 +28,13 @@ import { DeleteFeedDialog } from "@/components/feed/DeleteFeedDialog";
 import { SidebarSettingsTheme } from "@/components/ui/sidebar-settings-theme";
 import {
   ALL_FEEDS_SELECTION,
-  Feed,
   FeedSelection,
   isFeedSelected,
 } from "@/lib/types";
-import { fetchNewCategoryCount } from "@/lib/api";
-import { queryKeys } from "@/lib/queryKeys";
 import {
-  NEW_COUNT_POLL_INTERVAL,
   SIDEBAR_WIDTH_COLLAPSED,
   SIDEBAR_WIDTH_EXPANDED,
 } from "@/lib/constants";
-import { shouldShowFolderUnreadBadge } from "./feedSelection";
-
-type RootItem =
-  | { kind: "folder"; order: number; id: number }
-  | { kind: "feed"; order: number; id: number };
 
 interface SidebarProps {
   isCollapsed: boolean;
@@ -71,127 +53,27 @@ export function Sidebar({
   onAddFeedClick,
   onAddFolderClick,
 }: SidebarProps) {
-  const { data: feeds, isLoading: isFeedsLoading } = useFeeds();
-  const { data: folders, isLoading: isFoldersLoading } = useFeedFolders();
-  const deleteFeed = useDeleteFeed();
-  const markAllRead = useMarkAllRead();
-  const updateFeed = useUpdateFeed();
-  const createFolder = useCreateFeedFolder();
-
-  const [feedToDelete, setFeedToDelete] = useState<Feed | null>(null);
-  const [feedToMove, setFeedToMove] = useState<Feed | null>(null);
-  const [expandedFolders, setExpandedFolders] = useLocalStorage<Record<number, boolean>>("expanded-folders", {});
-
-  const { data: newCatCount } = useQuery({
-    queryKey: queryKeys.categories.newCount,
-    queryFn: fetchNewCategoryCount,
-    refetchInterval: NEW_COUNT_POLL_INTERVAL,
-  });
-  const hasNewCategories = (newCatCount?.count ?? 0) > 0;
-
-  const totalUnread = feeds?.reduce((sum, feed) => sum + feed.unread_count, 0) ?? 0;
-
-  const feedsByFolder = useMemo(() => {
-    const grouped = new Map<number, Feed[]>();
-    for (const feed of feeds ?? []) {
-      if (feed.folder_id === null) continue;
-      const list = grouped.get(feed.folder_id) ?? [];
-      list.push(feed);
-      grouped.set(feed.folder_id, list);
-    }
-
-    for (const list of grouped.values()) {
-      list.sort((a, b) => a.display_order - b.display_order || a.id - b.id);
-    }
-
-    return grouped;
-  }, [feeds]);
-
-  const ungroupedFeeds = useMemo(
-    () =>
-      (feeds ?? [])
-        .filter((feed) => feed.folder_id === null)
-        .sort((a, b) => a.display_order - b.display_order || a.id - b.id),
-    [feeds]
-  );
-
-  const orderedFolders = useMemo(
-    () =>
-      [...(folders ?? [])].sort(
-        (a, b) => a.display_order - b.display_order || a.id - b.id
-      ),
-    [folders]
-  );
-
-  const rootItems = useMemo<RootItem[]>(() => {
-    const items: RootItem[] = [
-      ...orderedFolders.map((folder) => ({
-        kind: "folder" as const,
-        order: folder.display_order,
-        id: folder.id,
-      })),
-      ...ungroupedFeeds.map((feed) => ({
-        kind: "feed" as const,
-        order: feed.display_order,
-        id: feed.id,
-      })),
-    ];
-
-    return items.sort((a, b) => {
-      if (a.order !== b.order) return a.order - b.order;
-      if (a.kind !== b.kind) return a.kind === "folder" ? -1 : 1;
-      return a.id - b.id;
-    });
-  }, [orderedFolders, ungroupedFeeds]);
-
-  const isLoading = isFeedsLoading || isFoldersLoading;
-  const hasItems = (feeds?.length ?? 0) + (folders?.length ?? 0) > 0;
-
-  const handleDeleteConfirm = (feedId: number) => {
-    deleteFeed.mutate(feedId);
-    if (isFeedSelected(selection, feedId)) {
-      onSelect(ALL_FEEDS_SELECTION);
-    }
-    setFeedToDelete(null);
-  };
-
-  const handleRename = (id: number, title: string) => {
-    updateFeed.mutate({ id, data: { title } });
-  };
-
-  const handleMarkAllRead = (feedId: number) => {
-    markAllRead.mutate(feedId);
-  };
-
-  const handleMoveFeed = (folderId: number | null) => {
-    if (!feedToMove) return;
-    updateFeed.mutate({
-      id: feedToMove.id,
-      data: { folder_id: folderId },
-    });
-    setFeedToMove(null);
-  };
-
-  const handleCreateFolderAndMove = async (folderName: string) => {
-    if (!feedToMove) return;
-
-    try {
-      await createFolder.mutateAsync({
-        name: folderName,
-        feedIds: [feedToMove.id],
-      });
-      setFeedToMove(null);
-    } catch {
-      // Global mutation error handling displays feedback.
-    }
-  };
-
-  const toggleFolderExpanded = (folderId: number) => {
-    setExpandedFolders((previous) => ({
-      ...previous,
-      [folderId]: !(previous[folderId] ?? true),
-    }));
-  };
+  const {
+    feedsByFolder,
+    ungroupedFeeds,
+    orderedFolders,
+    rootItems,
+    isLoading,
+    hasItems,
+    totalUnread,
+    hasNewCategories,
+    expandedFolders,
+    feedToDelete,
+    setFeedToDelete,
+    feedToMove,
+    setFeedToMove,
+    handleDeleteConfirm,
+    handleRename,
+    handleMarkAllRead,
+    handleMoveFeed,
+    handleCreateFolderAndMove,
+    toggleFolderExpanded,
+  } = useSidebarData(selection, onSelect);
 
   return (
     <Box
@@ -398,7 +280,7 @@ export function Sidebar({
                             <Text fontSize="sm" fontWeight="medium" flex={1} truncate>
                               {folder.name}
                             </Text>
-                            {shouldShowFolderUnreadBadge(folder.unread_count) ? (
+                            {folder.unread_count > 0 ? (
                               <Badge colorPalette="accent" size="sm">
                                 {folder.unread_count}
                               </Badge>

--- a/frontend/src/components/layout/feedSelection.test.tsx
+++ b/frontend/src/components/layout/feedSelection.test.tsx
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
   parseStoredFeedSelection,
-  shouldShowFolderUnreadBadge,
   validateFeedSelection,
 } from "./feedSelection";
 import { ALL_FEEDS_SELECTION, Feed, FeedFolder } from "@/lib/types";
@@ -30,11 +29,6 @@ function makeFolder(id: number): FeedFolder {
 }
 
 describe("sidebar folder helpers", () => {
-  it("shows folder unread badge only when unread count is greater than zero", () => {
-    expect(shouldShowFolderUnreadBadge(0)).toBe(false);
-    expect(shouldShowFolderUnreadBadge(4)).toBe(true);
-  });
-
   it("falls back to all selection when selected feed no longer exists", () => {
     const selection = { kind: "feed", feedId: 123 } as const;
     const validated = validateFeedSelection(selection, [makeFeed(1)], [makeFolder(1)]);

--- a/frontend/src/components/layout/feedSelection.ts
+++ b/frontend/src/components/layout/feedSelection.ts
@@ -58,7 +58,3 @@ export function validateFeedSelection(
 
   return ALL_FEEDS_SELECTION;
 }
-
-export function shouldShowFolderUnreadBadge(unreadCount: number): boolean {
-  return unreadCount > 0;
-}

--- a/frontend/src/components/settings/CategoryChildRow.tsx
+++ b/frontend/src/components/settings/CategoryChildRow.tsx
@@ -12,7 +12,6 @@ interface CategoryChildRowProps {
   category: Category;
   weight: string;
   isOverridden: boolean;
-  parentWeight: string;
 }
 
 const CategoryChildRowComponent = ({

--- a/frontend/src/components/settings/CategoryTree.tsx
+++ b/frontend/src/components/settings/CategoryTree.tsx
@@ -143,7 +143,6 @@ function CategoryTreeParent({
                     category={child}
                     weight={effectiveWeight}
                     isOverridden={isOverridden}
-                    parentWeight={parentWeight}
                   />
                 </Box>
               );

--- a/frontend/src/hooks/useFeedMutations.ts
+++ b/frontend/src/hooks/useFeedMutations.ts
@@ -9,7 +9,7 @@ import {
   markAllFeedRead,
   markAllArticlesRead,
 } from "@/lib/api";
-import { queryKeys } from "@/lib/queryKeys";
+import { queryKeys, invalidateFeedDependents } from "@/lib/queryKeys";
 
 export function useAddFeed() {
   const queryClient = useQueryClient();
@@ -17,11 +17,7 @@ export function useAddFeed() {
   return useMutation({
     mutationFn: (url: string) => createFeed(url),
     meta: { errorTitle: "Failed to add feed" },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.feeds.all });
-      queryClient.invalidateQueries({ queryKey: queryKeys.feedFolders.all });
-      queryClient.invalidateQueries({ queryKey: queryKeys.articles.all });
-    },
+    onSuccess: () => invalidateFeedDependents(queryClient),
   });
 }
 
@@ -31,11 +27,7 @@ export function useDeleteFeed() {
   return useMutation({
     mutationFn: (id: number) => deleteFeed(id),
     meta: { errorTitle: "Failed to delete feed" },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.feeds.all });
-      queryClient.invalidateQueries({ queryKey: queryKeys.feedFolders.all });
-      queryClient.invalidateQueries({ queryKey: queryKeys.articles.all });
-    },
+    onSuccess: () => invalidateFeedDependents(queryClient),
   });
 }
 
@@ -51,11 +43,7 @@ export function useUpdateFeed() {
       data: { title?: string; display_order?: number; folder_id?: number | null };
     }) => updateFeed(id, data),
     meta: { errorTitle: "Failed to update feed" },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.feeds.all });
-      queryClient.invalidateQueries({ queryKey: queryKeys.feedFolders.all });
-      queryClient.invalidateQueries({ queryKey: queryKeys.articles.all });
-    },
+    onSuccess: () => invalidateFeedDependents(queryClient),
   });
 }
 
@@ -84,11 +72,7 @@ export function useMarkAllRead() {
   return useMutation({
     mutationFn: (feedId: number) => markAllFeedRead(feedId),
     meta: { errorTitle: "Failed to mark feed as read" },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.feeds.all });
-      queryClient.invalidateQueries({ queryKey: queryKeys.feedFolders.all });
-      queryClient.invalidateQueries({ queryKey: queryKeys.articles.all });
-    },
+    onSuccess: () => invalidateFeedDependents(queryClient),
   });
 }
 
@@ -98,10 +82,6 @@ export function useMarkAllArticlesRead() {
   return useMutation({
     mutationFn: () => markAllArticlesRead(),
     meta: { errorTitle: "Failed to mark all articles read" },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.articles.all });
-      queryClient.invalidateQueries({ queryKey: queryKeys.feeds.all });
-      queryClient.invalidateQueries({ queryKey: queryKeys.feedFolders.all });
-    },
+    onSettled: () => invalidateFeedDependents(queryClient),
   });
 }

--- a/frontend/src/hooks/useSidebarData.ts
+++ b/frontend/src/hooks/useSidebarData.ts
@@ -1,0 +1,179 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
+import { useQuery } from "@tanstack/react-query";
+import { useFeeds } from "@/hooks/useFeeds";
+import {
+  useDeleteFeed,
+  useMarkAllRead,
+  useUpdateFeed,
+} from "@/hooks/useFeedMutations";
+import { useCreateFeedFolder, useFeedFolders } from "@/hooks/useFeedFolders";
+import {
+  ALL_FEEDS_SELECTION,
+  Feed,
+  FeedSelection,
+  isFeedSelected,
+} from "@/lib/types";
+import { fetchNewCategoryCount } from "@/lib/api";
+import { queryKeys } from "@/lib/queryKeys";
+import { NEW_COUNT_POLL_INTERVAL } from "@/lib/constants";
+
+export type RootItem =
+  | { kind: "folder"; order: number; id: number }
+  | { kind: "feed"; order: number; id: number };
+
+export function useSidebarData(
+  selection: FeedSelection,
+  onSelect: (selection: FeedSelection) => void,
+) {
+  const { data: feeds, isLoading: isFeedsLoading } = useFeeds();
+  const { data: folders, isLoading: isFoldersLoading } = useFeedFolders();
+  const deleteFeed = useDeleteFeed();
+  const markAllRead = useMarkAllRead();
+  const updateFeed = useUpdateFeed();
+  const createFolder = useCreateFeedFolder();
+
+  const [feedToDelete, setFeedToDelete] = useState<Feed | null>(null);
+  const [feedToMove, setFeedToMove] = useState<Feed | null>(null);
+  const [expandedFolders, setExpandedFolders] = useLocalStorage<
+    Record<number, boolean>
+  >("expanded-folders", {});
+
+  const { data: newCatCount } = useQuery({
+    queryKey: queryKeys.categories.newCount,
+    queryFn: fetchNewCategoryCount,
+    refetchInterval: NEW_COUNT_POLL_INTERVAL,
+  });
+  const hasNewCategories = (newCatCount?.count ?? 0) > 0;
+
+  const totalUnread =
+    feeds?.reduce((sum, feed) => sum + feed.unread_count, 0) ?? 0;
+
+  const feedsByFolder = useMemo(() => {
+    const grouped = new Map<number, Feed[]>();
+    for (const feed of feeds ?? []) {
+      if (feed.folder_id === null) continue;
+      const list = grouped.get(feed.folder_id) ?? [];
+      list.push(feed);
+      grouped.set(feed.folder_id, list);
+    }
+
+    for (const list of grouped.values()) {
+      list.sort((a, b) => a.display_order - b.display_order || a.id - b.id);
+    }
+
+    return grouped;
+  }, [feeds]);
+
+  const ungroupedFeeds = useMemo(
+    () =>
+      (feeds ?? [])
+        .filter((feed) => feed.folder_id === null)
+        .sort((a, b) => a.display_order - b.display_order || a.id - b.id),
+    [feeds],
+  );
+
+  const orderedFolders = useMemo(
+    () =>
+      [...(folders ?? [])].sort(
+        (a, b) => a.display_order - b.display_order || a.id - b.id,
+      ),
+    [folders],
+  );
+
+  const rootItems = useMemo<RootItem[]>(() => {
+    const items: RootItem[] = [
+      ...orderedFolders.map((folder) => ({
+        kind: "folder" as const,
+        order: folder.display_order,
+        id: folder.id,
+      })),
+      ...ungroupedFeeds.map((feed) => ({
+        kind: "feed" as const,
+        order: feed.display_order,
+        id: feed.id,
+      })),
+    ];
+
+    return items.sort((a, b) => {
+      if (a.order !== b.order) return a.order - b.order;
+      if (a.kind !== b.kind) return a.kind === "folder" ? -1 : 1;
+      return a.id - b.id;
+    });
+  }, [orderedFolders, ungroupedFeeds]);
+
+  const isLoading = isFeedsLoading || isFoldersLoading;
+  const hasItems = (feeds?.length ?? 0) + (folders?.length ?? 0) > 0;
+
+  const handleDeleteConfirm = (feedId: number) => {
+    deleteFeed.mutate(feedId);
+    if (isFeedSelected(selection, feedId)) {
+      onSelect(ALL_FEEDS_SELECTION);
+    }
+    setFeedToDelete(null);
+  };
+
+  const handleRename = (id: number, title: string) => {
+    updateFeed.mutate({ id, data: { title } });
+  };
+
+  const handleMarkAllRead = (feedId: number) => {
+    markAllRead.mutate(feedId);
+  };
+
+  const handleMoveFeed = (folderId: number | null) => {
+    if (!feedToMove) return;
+    updateFeed.mutate({
+      id: feedToMove.id,
+      data: { folder_id: folderId },
+    });
+    setFeedToMove(null);
+  };
+
+  const handleCreateFolderAndMove = async (folderName: string) => {
+    if (!feedToMove) return;
+
+    try {
+      await createFolder.mutateAsync({
+        name: folderName,
+        feedIds: [feedToMove.id],
+      });
+      setFeedToMove(null);
+    } catch {
+      // Global mutation error handling displays feedback.
+    }
+  };
+
+  const toggleFolderExpanded = (folderId: number) => {
+    setExpandedFolders((previous) => ({
+      ...previous,
+      [folderId]: !(previous[folderId] ?? true),
+    }));
+  };
+
+  return {
+    feeds,
+    folders,
+    feedsByFolder,
+    ungroupedFeeds,
+    orderedFolders,
+    rootItems,
+    isLoading,
+    hasItems,
+    totalUnread,
+    hasNewCategories,
+    expandedFolders,
+    feedToDelete,
+    setFeedToDelete,
+    feedToMove,
+    setFeedToMove,
+    handleDeleteConfirm,
+    handleRename,
+    handleMarkAllRead,
+    handleMoveFeed,
+    handleCreateFolderAndMove,
+    toggleFolderExpanded,
+  };
+}

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -9,8 +9,6 @@ export const SIDEBAR_WIDTH_EXPANDED = "240px";
 export const NEW_COUNT_POLL_INTERVAL = 30_000;
 /** Score threshold for accent-colored score badge */
 export const HIGH_SCORE_THRESHOLD = 15;
-/** Default page size for article list pagination */
-export const ARTICLE_LIST_PAGE_SIZE = 50;
 
 export type SettingsSection =
   | "general"

--- a/frontend/src/lib/queryKeys.ts
+++ b/frontend/src/lib/queryKeys.ts
@@ -47,3 +47,11 @@ export function invalidateModelDependents(queryClient: QueryClient) {
   queryClient.invalidateQueries({ queryKey: queryKeys.models.available });
   queryClient.invalidateQueries({ queryKey: queryKeys.taskRoutes.all });
 }
+
+/** Invalidate caches that depend on feed state.
+ *  Call after any mutation that changes feeds, folders, or article counts. */
+export function invalidateFeedDependents(queryClient: QueryClient) {
+  queryClient.invalidateQueries({ queryKey: queryKeys.feeds.all });
+  queryClient.invalidateQueries({ queryKey: queryKeys.feedFolders.all });
+  queryClient.invalidateQueries({ queryKey: queryKeys.articles.all });
+}


### PR DESCRIPTION
# refactor: simplify frontend — extract useSidebarData, DRY feed mutations, remove dead code

## What is this PR about?

Frontend-only code quality improvements: extract shared sidebar data logic into a hook, consolidate repeated query invalidation, and remove dead code. No functionality or design changes.

## Why is this change needed?

`Sidebar` and `MobileSidebar` had ~150 lines of identical data logic copy-pasted between them, and feed mutations repeated the same 3 `invalidateQueries` calls in 5 places. Several smaller pieces of dead code (unused exports, a trivial wrapper function, a duplicate event listener) added maintenance noise.

## How is this change implemented?

- Extract `useSidebarData` hook from `Sidebar`/`MobileSidebar` — eliminates ~150 lines of duplicated feed/folder data logic, memos, state, and handlers
- Add `invalidateFeedDependents(queryClient)` helper to `queryKeys.ts` (mirrors existing `invalidateModelDependents`) — replaces 15 scattered `invalidateQueries` calls across 5 feed mutations
- Fix `longPressTimer` in `FeedRow`: `useState` → `useRef` to avoid 3 unnecessary re-renders per touch interaction
- Remove dead `ARTICLE_LIST_PAGE_SIZE` export from `constants.ts`, trivial `shouldShowFolderUnreadBadge` wrapper, duplicate Escape key `useEffect` in `ArticleList`, and unused `parentWeight` prop on `CategoryChildRow`

## How to test this change?

1. Open the app and verify the sidebar shows feeds/folders, unread badges, and folder expand/collapse
2. On mobile (or DevTools responsive mode), open the drawer and verify feed selection closes it; swipe a feed row to reveal actions
3. Open an article, press Escape — reader should close; press j/k to navigate
4. Navigate to Settings → Categories and verify child rows render with context menus

## Notes

- All 27 existing tests pass; build is clean
- Backend unchanged