### PR TITLE
fix: make categories action bar sticky on desktop

### DIFF
--- a/frontend/src/components/settings/CategoryActionBar.tsx
+++ b/frontend/src/components/settings/CategoryActionBar.tsx
@@ -25,7 +25,7 @@ export function CategoryActionBar({
 }: CategoryActionBarProps) {
   return (
     <>
-      {/* Desktop: static header */}
+      {/* Desktop: sticky header */}
       <Flex
         display={{ base: "none", sm: "flex" }}
         alignItems="center"
@@ -33,6 +33,8 @@ export function CategoryActionBar({
         px={3}
         bg="bg.subtle"
         borderRadius="sm"
+        borderBottomWidth="1px"
+        borderColor="border.subtle"
         position="sticky"
         top={0}
         zIndex={1}

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -32,6 +32,8 @@ export const system = createSystem(defaultConfig, {
   globalCss: {
     "html, body": {
       colorScheme: "dark",
+    },
+    body: {
       maxWidth: "100vw",
       overflowX: "hidden",
     },


### PR DESCRIPTION
# fix: make categories action bar sticky on desktop

## What is this PR about?

The desktop action bar on the Categories settings page now stays sticky at the top of the viewport when scrolling, so bulk actions remain accessible.

## Why is this change needed?

With many categories, users had to scroll back to the top to access bulk actions (Move to group, Ungroup, Hide, Delete). The action bar had `position: sticky` but it wasn't working. Fixes #81.

## How is this change implemented?

- Moved `overflowX: hidden` from `html, body` to `body` only in the global CSS — `overflow` on `<html>` creates a scroll container that disables `position: sticky` for all descendants
- Added a subtle bottom border to the action bar for visual separation when stuck
- Updated the code comment from "static header" to "sticky header"

## How to test this change?

1. Open Settings → Categories (need enough categories to scroll)
2. Scroll down — the action bar should stick at the top of the viewport
3. Verify no horizontal scrollbar appears on narrow viewports
4. Verify the mobile floating pill action bar still works on small screens

## Notes

- No backend changes
- The `overflowX: hidden` on `body` still prevents horizontal scrollbar; only `html` needed to be freed from it