### PR TITLE
fix: enforce structured output validation for LLM providers

### DIFF
--- a/backend/src/backend/llm_providers/base.py
+++ b/backend/src/backend/llm_providers/base.py
@@ -1,10 +1,80 @@
 """Provider contracts for pluggable LLM integrations."""
 
+from __future__ import annotations
+
+import json
+import logging
 from dataclasses import dataclass
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
+
+from pydantic import BaseModel
 
 from backend.prompts import ArticleCategoryResult, ArticleScoringResult
 from backend.prompts.grouping import GroupingResponse
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+_RAW_PREVIEW_CHARS = 500
+
+
+class LLMValidationError(Exception):
+    """LLM returned output that failed schema validation.
+
+    Attributes:
+        raw_response: The full raw text the LLM returned (or None if empty).
+        original_exc: The underlying parse/validation exception.
+        is_retryable: True for empty/truncated/malformed JSON (transient);
+                      False for valid JSON that violates schema constraints (deterministic).
+    """
+
+    def __init__(
+        self,
+        raw_response: str | None,
+        original_exc: Exception | None,
+        *,
+        is_retryable: bool,
+    ) -> None:
+        self.raw_response = raw_response
+        self.original_exc = original_exc
+        self.is_retryable = is_retryable
+        preview = (raw_response or "<empty>")[:_RAW_PREVIEW_CHARS]
+        retryable_tag = "retryable" if is_retryable else "deterministic"
+        super().__init__(
+            f"LLM output failed validation ({retryable_tag}): {original_exc}\n"
+            f"Raw response (truncated): {preview}"
+        )
+
+
+def validate_llm_response[T: BaseModel](raw: str | None, schema: type[T]) -> T:
+    """Validate raw LLM JSON against a Pydantic schema.
+
+    Uses a two-step parse: json.loads to classify failure type, then
+    model_validate_json for authoritative validation.
+
+    Raises:
+        LLMValidationError: Always. is_retryable=True for empty/malformed JSON,
+                            is_retryable=False for valid JSON that fails schema.
+    """
+    stripped = (raw or "").strip()
+    if not stripped:
+        raise LLMValidationError(
+            raw, ValueError("LLM returned empty response"), is_retryable=True
+        )
+
+    # Step 1: Can we parse it as JSON at all?
+    try:
+        json.loads(stripped)
+    except json.JSONDecodeError as e:
+        raise LLMValidationError(raw, e, is_retryable=True) from e
+
+    # Step 2: Does it match the Pydantic schema?
+    try:
+        return schema.model_validate_json(stripped)
+    except Exception as e:
+        raise LLMValidationError(raw, e, is_retryable=False) from e
 
 
 @dataclass

--- a/backend/src/backend/llm_providers/google.py
+++ b/backend/src/backend/llm_providers/google.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from datetime import datetime
@@ -291,18 +292,44 @@ class GoogleProvider:
         from google import genai
         from google.genai import types
 
+        from backend.llm_providers.base import LLMValidationError, validate_llm_response
+
         client = genai.Client(api_key=config.api_key)
-        response = await client.aio.models.generate_content(
-            model=config.model,  # pyright: ignore[reportArgumentType]
-            contents=user_message,
-            config=types.GenerateContentConfig(
-                system_instruction=system_prompt,
-                response_mime_type="application/json",
-                response_schema=schema.model_json_schema(),
-                temperature=0,
-            ),
-        )
-        return schema.model_validate_json(response.text)  # pyright: ignore[reportArgumentType]
+
+        last_error: LLMValidationError | None = None
+        for attempt in range(2):
+            response = await client.aio.models.generate_content(
+                model=config.model,  # pyright: ignore[reportArgumentType]
+                contents=user_message,
+                config=types.GenerateContentConfig(
+                    system_instruction=system_prompt,
+                    response_mime_type="application/json",
+                    response_schema=schema.model_json_schema(),
+                    temperature=0,
+                ),
+            )
+
+            if response.text is None:
+                logger.debug(
+                    "Google returned null text; candidates=%s",
+                    response.candidates,
+                )
+
+            try:
+                return validate_llm_response(response.text, schema)
+            except LLMValidationError as e:
+                last_error = e
+                logger.warning(
+                    "Google LLM validation failed (attempt %d/2): %s",
+                    attempt + 1,
+                    e,
+                )
+                if not e.is_retryable or attempt > 0:
+                    break
+                await asyncio.sleep(1)
+
+        assert last_error is not None  # loop always runs at least once
+        raise last_error
 
     async def categorize(
         self,

--- a/backend/src/backend/llm_providers/ollama.py
+++ b/backend/src/backend/llm_providers/ollama.py
@@ -11,12 +11,14 @@ from ollama import AsyncClient
 from pydantic import BaseModel, Field, field_validator
 from tenacity import (
     retry,
+    retry_if_exception,
     retry_if_exception_type,
     stop_after_attempt,
     wait_exponential,
 )
 
 from backend import ollama_service
+from backend.llm_providers.base import LLMValidationError, validate_llm_response
 from backend.scoring import set_categorization_phase, set_scoring_phase
 
 if TYPE_CHECKING:
@@ -91,14 +93,19 @@ TRANSIENT_ERRORS = (
     httpx.ConnectTimeout,
 )
 
+_RETRYABLE = retry_if_exception_type(TRANSIENT_ERRORS) | retry_if_exception(
+    lambda e: isinstance(e, LLMValidationError) and e.is_retryable
+)
+
 
 # --- Scoring / categorization functions ---
 
 
 @retry(
-    retry=retry_if_exception_type(TRANSIENT_ERRORS),
+    retry=_RETRYABLE,
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=1, min=2, max=10),
+    reraise=True,
 )
 async def categorize_article(
     article_title: str,
@@ -154,7 +161,7 @@ async def categorize_article(
         content += chunk["message"].get("content") or ""
 
     # Parse accumulated structured response
-    result = CategoryResponse.model_validate_json(content)
+    result = validate_llm_response(content, CategoryResponse)
 
     logger.info(
         f"Categorized article: {len(result.categories)} categories, "
@@ -165,9 +172,10 @@ async def categorize_article(
 
 
 @retry(
-    retry=retry_if_exception_type(TRANSIENT_ERRORS),
+    retry=_RETRYABLE,
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=1, min=2, max=10),
+    reraise=True,
 )
 async def score_article(
     article_title: str,
@@ -217,7 +225,7 @@ async def score_article(
         content += chunk["message"].get("content") or ""
 
     # Parse accumulated structured response
-    result = ScoringResponse.model_validate_json(content)
+    result = validate_llm_response(content, ScoringResponse)
 
     logger.info(
         f"Scored article: interest={result.interest_score}, "
@@ -228,9 +236,10 @@ async def score_article(
 
 
 @retry(
-    retry=retry_if_exception_type(TRANSIENT_ERRORS),
+    retry=_RETRYABLE,
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=1, min=2, max=10),
+    reraise=True,
 )
 async def categorize_articles(
     articles: list[dict],
@@ -281,15 +290,16 @@ async def categorize_articles(
             set_categorization_phase("categorizing")
         content += chunk["message"].get("content") or ""
 
-    result = BatchCategoryResponse.model_validate_json(content)
+    result = validate_llm_response(content, BatchCategoryResponse)
     logger.info("Categorized %d articles in batch", len(result.results))
     return result.results
 
 
 @retry(
-    retry=retry_if_exception_type(TRANSIENT_ERRORS),
+    retry=_RETRYABLE,
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=1, min=2, max=10),
+    reraise=True,
 )
 async def score_articles(
     articles: list[dict],
@@ -335,7 +345,7 @@ async def score_articles(
             set_scoring_phase("scoring")
         content += chunk["message"].get("content") or ""
 
-    result = BatchScoringResponse.model_validate_json(content)
+    result = validate_llm_response(content, BatchScoringResponse)
     logger.info("Scored %d articles in batch", len(result.results))
     return result.results
 
@@ -497,7 +507,7 @@ class OllamaProvider:
         ):
             content += chunk["message"].get("content") or ""
 
-        result = GroupingResponse.model_validate_json(content)
+        result = validate_llm_response(content, GroupingResponse)
         logger.info("Suggested %d category groups", len(result.groups))
         return result
 

--- a/backend/tests/test_llm_validation.py
+++ b/backend/tests/test_llm_validation.py
@@ -1,0 +1,73 @@
+"""Tests for the shared LLM response validation helper."""
+
+import pytest
+from pydantic import BaseModel, Field
+
+from backend.llm_providers.base import LLMValidationError, validate_llm_response
+
+
+class ScoreModel(BaseModel):
+    """Minimal model for testing validation constraints."""
+
+    score: int = Field(ge=0, le=10)
+    label: str
+
+
+class TestValidateLlmResponse:
+    def test_valid_json(self):
+        result = validate_llm_response('{"score": 5, "label": "good"}', ScoreModel)
+        assert result.score == 5
+        assert result.label == "good"
+
+    def test_none_raises_retryable(self):
+        with pytest.raises(LLMValidationError) as exc_info:
+            validate_llm_response(None, ScoreModel)
+        assert exc_info.value.is_retryable is True
+        assert exc_info.value.raw_response is None
+
+    def test_empty_string_raises_retryable(self):
+        with pytest.raises(LLMValidationError) as exc_info:
+            validate_llm_response("", ScoreModel)
+        assert exc_info.value.is_retryable is True
+
+    def test_whitespace_only_raises_retryable(self):
+        with pytest.raises(LLMValidationError) as exc_info:
+            validate_llm_response("   \n\t  ", ScoreModel)
+        assert exc_info.value.is_retryable is True
+
+    def test_malformed_json_raises_retryable(self):
+        raw = '{"score": 5, "label": '
+        with pytest.raises(LLMValidationError) as exc_info:
+            validate_llm_response(raw, ScoreModel)
+        assert exc_info.value.is_retryable is True
+        assert exc_info.value.raw_response == raw
+
+    def test_schema_violation_raises_non_retryable(self):
+        """Valid JSON but score=15 violates ge=0, le=10 constraint."""
+        raw = '{"score": 15, "label": "too high"}'
+        with pytest.raises(LLMValidationError) as exc_info:
+            validate_llm_response(raw, ScoreModel)
+        assert exc_info.value.is_retryable is False
+        assert exc_info.value.raw_response == raw
+
+    def test_missing_field_raises_non_retryable(self):
+        """Valid JSON but missing required field."""
+        raw = '{"score": 5}'
+        with pytest.raises(LLMValidationError) as exc_info:
+            validate_llm_response(raw, ScoreModel)
+        assert exc_info.value.is_retryable is False
+
+    def test_long_response_truncated_in_message(self):
+        raw = '{"score": 15, "label": "' + "x" * 1000 + '"}'
+        with pytest.raises(LLMValidationError) as exc_info:
+            validate_llm_response(raw, ScoreModel)
+        # Full raw preserved on attribute
+        assert len(exc_info.value.raw_response) > 500
+        # Message is truncated
+        assert len(str(exc_info.value)) < len(exc_info.value.raw_response)
+
+    def test_exception_chaining(self):
+        with pytest.raises(LLMValidationError) as exc_info:
+            validate_llm_response("not json", ScoreModel)
+        assert exc_info.value.__cause__ is not None
+        assert exc_info.value.original_exc is not None


### PR DESCRIPTION
# Enforce structured output validation for LLM providers

## What is this PR about?

Adds error handling and retry logic around all `model_validate_json()` calls in both LLM providers (Google Gemini and Ollama), so malformed LLM responses are caught, logged with the raw output, and retried when appropriate.

## Why is this change needed?

Both providers had zero error handling around response parsing — a non-conforming LLM response would crash with an unhelpful error and the raw output was lost, making debugging impossible. Google's `response.text` being `None` (blocked/empty response) also caused confusing crashes.

## How is this change implemented?

- Shared `LLMValidationError` exception and `validate_llm_response()` helper in `base.py` with two-step parse: `json.loads` classifies failure type, `model_validate_json` validates schema
- Errors classified as retryable (malformed/empty JSON) vs deterministic (valid JSON, wrong schema) to prevent wasteful retries
- Google provider: 2-attempt loop retrying only retryable failures, with null response metadata logging
- Ollama provider: custom tenacity retry predicate for retryable validation errors alongside existing network error retries, plus `reraise=True` on all decorators
- 9 unit tests covering the validation helper

## How to test this change?

1. Run `uv run pytest backend/tests/test_llm_validation.py -v` to verify the new tests
2. Run `uv run pytest` to confirm the full suite passes (229 tests)
3. Trigger article scoring with a configured provider to verify normal operation is unaffected

## Notes

- Queue-level retry in `scoring_queue.py` is untouched — still the last-resort fallback
- `suggest_groups()` (user-triggered, outside queue) has no queue-level retry fallback — accepted gap for a single-user app

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)