### PR TITLE
fix: two-phase LLM grouping to reduce ungrouped categories (#79)

### DIFF
--- a/backend/src/backend/llm_providers/google.py
+++ b/backend/src/backend/llm_providers/google.py
@@ -18,7 +18,12 @@ from backend.prompts import (
     build_batch_categorization_prompt,
     build_batch_scoring_prompt,
 )
-from backend.prompts.grouping import GroupingResponse, build_grouping_prompt
+from backend.prompts.grouping import (
+    GroupingResponse,
+    ThemeResponse,
+    build_assignment_prompt,
+    build_theme_proposal_prompt,
+)
 
 if TYPE_CHECKING:
     from sqlmodel import Session
@@ -373,9 +378,16 @@ class GoogleProvider:
         existing_groups: dict[str, list[str]],
         config: ProviderTaskConfig,
     ) -> GroupingResponse:
-        prompt = build_grouping_prompt(all_categories, existing_groups)
-        # Grouping uses a single prompt — pass it as user message with empty system prompt
-        result = await self._generate(config, "", prompt, GroupingResponse)
+        # Phase 1: Propose themes
+        theme_prompt = build_theme_proposal_prompt(all_categories)
+        theme_result = await self._generate(config, "", theme_prompt, ThemeResponse)
+
+        if not theme_result.themes:
+            return GroupingResponse(groups=[])
+
+        # Phase 2: Assign categories to themes
+        assignment_prompt = build_assignment_prompt(all_categories, theme_result.themes)
+        result = await self._generate(config, "", assignment_prompt, GroupingResponse)
         logger.info("Google suggested %d category groups", len(result.groups))
         return result
 

--- a/backend/src/backend/llm_providers/ollama.py
+++ b/backend/src/backend/llm_providers/ollama.py
@@ -38,7 +38,12 @@ from backend.prompts import (
     build_categorization_prompt,
     build_scoring_prompt,
 )
-from backend.prompts.grouping import GroupingResponse, build_grouping_prompt
+from backend.prompts.grouping import (
+    GroupingResponse,
+    ThemeResponse,
+    build_assignment_prompt,
+    build_theme_proposal_prompt,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -494,13 +499,31 @@ class OllamaProvider:
         existing_groups: dict[str, list[str]],
         config: ProviderTaskConfig,
     ) -> GroupingResponse:
-        prompt = build_grouping_prompt(all_categories, existing_groups)
-
         client = get_ollama_client(config.endpoint)
+
+        # Phase 1: Propose themes
+        theme_prompt = build_theme_proposal_prompt(all_categories)
         content = ""
         async for chunk in await client.chat(
             model=config.model,
-            messages=[{"role": "user", "content": prompt}],
+            messages=[{"role": "user", "content": theme_prompt}],
+            format=ThemeResponse.model_json_schema(),
+            options={"temperature": 0},
+            stream=True,
+        ):
+            content += chunk["message"].get("content") or ""
+
+        theme_result = validate_llm_response(content, ThemeResponse)
+
+        if not theme_result.themes:
+            return GroupingResponse(groups=[])
+
+        # Phase 2: Assign categories to themes
+        assignment_prompt = build_assignment_prompt(all_categories, theme_result.themes)
+        content = ""
+        async for chunk in await client.chat(
+            model=config.model,
+            messages=[{"role": "user", "content": assignment_prompt}],
             format=GroupingResponse.model_json_schema(),
             options={"temperature": 0},
             stream=True,

--- a/backend/src/backend/prompts/grouping.py
+++ b/backend/src/backend/prompts/grouping.py
@@ -27,17 +27,16 @@ def build_theme_proposal_prompt(all_categories: list[str]) -> str:
     """
     categories_list = "\n".join(f"- {name}" for name in sorted(all_categories))
 
-    return f"""Propose broad thematic group names that could organize these categories.
+    return f"""Propose parent group names that could organize the categories listed below.
+
+**Rules:**
+1. Theme names should be concise (1-2 words).
+2. Themes may reuse a category name if it works as a broader parent.
+3. Each theme should cover a distinct topic. If a theme would span multiple clearly different sub-domains, split it into separate, more specific themes.
+4. Propose enough themes to cover as many categories as possible. No single theme should need more than ~25 children.
 
 **All categories:**
 {categories_list}
-
-**Rules:**
-1. Themes should be broader than individual categories — each theme is a potential parent group name.
-2. Aim for themes that could each contain 2-20 categories.
-3. Propose enough themes to cover most categories.
-4. Theme names should be concise and descriptive (1-3 words).
-5. Do not reuse exact category names as themes — create broader labels.
 
 Propose the themes now."""
 
@@ -51,22 +50,21 @@ def build_assignment_prompt(all_categories: list[str], themes: list[str]) -> str
     categories_list = "\n".join(f"- {name}" for name in sorted(all_categories))
     themes_list = "\n".join(f"- {theme}" for theme in themes)
 
-    return f"""Assign each category to the best-fitting theme. Each theme becomes a parent group.
-
-**All categories:**
-{categories_list}
+    return f"""Assign each category below to the best-fitting theme. Each theme becomes a parent group.
 
 **Proposed themes:**
 {themes_list}
 
+**All categories:**
+{categories_list}
+
 **Rules (follow strictly):**
 1. Use the provided category names exactly as written for children.
 2. Use the proposed theme names as parent group names.
-3. Each group must have at least two children. Never create a group with only one child — leave those categories ungrouped instead.
-4. Categories that do not clearly fit any theme may remain ungrouped.
+3. Each group must have at least two children.
+4. Prefer assigning categories to a theme. Only leave a category ungrouped if it truly does not fit any theme. However, do not force unrelated categories into the same group just because the theme name is broad enough.
 5. No nested groups — only one level of parent-child.
 6. Each category may appear in at most one group.
-7. If a group would have more than 15-20 children, break it into multiple smaller, more focused groups.
 
 Assign the categories now."""
 

--- a/backend/src/backend/prompts/grouping.py
+++ b/backend/src/backend/prompts/grouping.py
@@ -35,6 +35,20 @@ def build_theme_proposal_prompt(all_categories: list[str]) -> str:
 3. Each theme should cover a distinct topic. If a theme would span multiple clearly different sub-domains, split it into separate, more specific themes.
 4. Propose enough themes to cover as many categories as possible. No single theme should need more than ~25 children.
 
+**Examples of good vs bad theme splitting:**
+
+Given categories: Piano, Drums, Oil Painting, Sculpture, Ballet, Jazz, Hip Hop
+- Bad: "Arts" (too broad — music, visual arts, and dance are distinct)
+- Good: "Music", "Visual Arts", "Dance"
+
+Given categories: Python, Docker, PostgreSQL, React, Kubernetes, MongoDB
+- Bad: "Software" (covers everything)
+- Good: "Programming Languages", "DevOps", "Databases", "Frontend"
+
+Given categories: Cycling, Nutrition, Yoga, Surgery, Pharmacy, Marathon
+- Bad: "Health" (mixes fitness, medicine, and diet)
+- Good: "Fitness", "Medicine", "Nutrition"
+
 **All categories:**
 {categories_list}
 
@@ -57,6 +71,23 @@ def build_assignment_prompt(all_categories: list[str], themes: list[str]) -> str
 
 **All categories:**
 {categories_list}
+
+**Examples of good vs bad assignment:**
+
+Themes: "Fitness", "Cooking", "Medicine"
+Categories: Yoga, Running, Recipes, Baking, Surgery, Pharmacy, Meal Prep, Stretching
+- Bad: leaving "Meal Prep" ungrouped because it's not exactly "Cooking"
+- Good: Fitness → Yoga, Running, Stretching | Cooking → Recipes, Baking, Meal Prep | Medicine → Surgery, Pharmacy
+
+Themes: "Programming Languages", "DevOps", "Databases"
+Categories: Python, Docker, PostgreSQL, CI/CD, Git, MySQL, Terraform, Ruby
+- Bad: leaving "Git" and "CI/CD" ungrouped because they aren't exactly "DevOps tools"
+- Good: Programming Languages → Python, Ruby | DevOps → Docker, CI/CD, Git, Terraform | Databases → PostgreSQL, MySQL
+
+Themes: "Wildlife", "Agriculture", "Climate"
+Categories: Bears, Farming, Drought, Irrigation, Wolves, Coral Reefs, Soil
+- Bad: leaving "Irrigation" and "Soil" ungrouped
+- Good: Wildlife → Bears, Wolves, Coral Reefs | Agriculture → Farming, Irrigation, Soil | Climate → Drought
 
 **Rules (follow strictly):**
 1. Use the provided category names exactly as written for children.

--- a/backend/src/backend/prompts/grouping.py
+++ b/backend/src/backend/prompts/grouping.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, Field
 
 
 class GroupSuggestion(BaseModel):
-    parent: str = Field(description="Existing category name to use as group parent")
+    parent: str = Field(description="Category name to use as group parent (may be new)")
     children: list[str] = Field(
         description="Existing category names to place under this parent", min_length=2
     )
@@ -14,6 +14,32 @@ class GroupingResponse(BaseModel):
     groups: list[GroupSuggestion] = Field(
         default_factory=list, description="Suggested groupings"
     )
+
+
+class ThemeResponse(BaseModel):
+    themes: list[str] = Field(description="Proposed parent group theme names")
+
+
+def build_theme_proposal_prompt(all_categories: list[str]) -> str:
+    """Build prompt asking the LLM to propose broad thematic parent group names.
+
+    This prompt deliberately omits existing groups to avoid anchoring bias.
+    """
+    categories_list = "\n".join(f"- {name}" for name in sorted(all_categories))
+
+    return f"""Propose broad thematic group names that could organize these categories.
+
+**All categories:**
+{categories_list}
+
+**Rules:**
+1. Themes should be broader than individual categories — each theme is a potential parent group name.
+2. Aim for themes that could each contain 2-20 categories.
+3. Propose enough themes to cover most categories.
+4. Theme names should be concise and descriptive (1-3 words).
+5. Do not reuse exact category names as themes — create broader labels.
+
+Propose the themes now."""
 
 
 def build_grouping_prompt(
@@ -39,8 +65,10 @@ def build_grouping_prompt(
             group_lines.append(f"  {parent} > {children_str}")
         existing_section = f"""
 
-**Current groups (for context):**
+**Current groups (these are incomplete — many categories above are not yet assigned to any group):**
 {chr(10).join(group_lines)}
+
+Review and improve these groups. Add ungrouped categories to existing groups where they logically fit, and create new groups where multiple ungrouped categories share a clear theme.
 """
 
     return f"""Group these categories into logical parent-child relationships.
@@ -49,11 +77,12 @@ def build_grouping_prompt(
 {categories_list}
 {existing_section}
 **Rules (follow strictly):**
-1. ONLY use the provided category names exactly as written. Do NOT create new categories.
+1. Use the provided category names exactly as written for children. Parent names may be new if no existing category fits as a good parent.
 2. Use broader categories as parents and narrower ones as children.
 3. Each group must have at least TWO children. Never create a group with only one child — leave those categories ungrouped instead.
-4. Categories that do not fit any group should remain unparented — do NOT force groupings.
+4. Categories that do not clearly fit any group may remain ungrouped — but before leaving a category unparented, check if it could join an existing group or form a new group with other ungrouped categories.
 5. No nested groups — only one level of parent-child.
 6. Each category may appear in at most ONE group — never assign the same category to multiple parents.
+7. Keep groups focused — if a group would have more than 15-20 children, break it into multiple smaller, more focused groups instead.
 
 Group these categories now."""

--- a/backend/src/backend/prompts/grouping.py
+++ b/backend/src/backend/prompts/grouping.py
@@ -42,6 +42,35 @@ def build_theme_proposal_prompt(all_categories: list[str]) -> str:
 Propose the themes now."""
 
 
+def build_assignment_prompt(all_categories: list[str], themes: list[str]) -> str:
+    """Build prompt asking the LLM to assign categories to proposed themes.
+
+    Takes the themes from phase 1 and asks the model to create parent-child
+    assignments using those themes as group parents.
+    """
+    categories_list = "\n".join(f"- {name}" for name in sorted(all_categories))
+    themes_list = "\n".join(f"- {theme}" for theme in themes)
+
+    return f"""Assign each category to the best-fitting theme. Each theme becomes a parent group.
+
+**All categories:**
+{categories_list}
+
+**Proposed themes:**
+{themes_list}
+
+**Rules (follow strictly):**
+1. Use the provided category names exactly as written for children.
+2. Use the proposed theme names as parent group names.
+3. Each group must have at least two children. Never create a group with only one child — leave those categories ungrouped instead.
+4. Categories that do not clearly fit any theme may remain ungrouped.
+5. No nested groups — only one level of parent-child.
+6. Each category may appear in at most one group.
+7. If a group would have more than 15-20 children, break it into multiple smaller, more focused groups.
+
+Assign the categories now."""
+
+
 def build_grouping_prompt(
     all_categories: list[str],
     existing_groups: dict[str, list[str]],

--- a/backend/src/backend/routers/categories.py
+++ b/backend/src/backend/routers/categories.py
@@ -314,22 +314,28 @@ async def auto_group_suggest(
     slug_to_name = {slugify(c.display_name): c.display_name for c in all_categories}
     valid_slugs = set(slug_to_name.keys())
 
-    # Filter groups: drop unknown parent/children, keep groups with ≥1 valid child.
-    # Resolve names back to canonical DB display_name via slug_to_name.
+    # Filter groups: drop unknown children, keep groups with ≥1 valid child.
+    # Allow new parent names (not in DB) — use canonical DB name if exists.
     valid_groups = []
+    seen_child_slugs: set[str] = set()
     for group in response.groups:
         parent_slug = slugify(group.parent)
-        if parent_slug not in valid_slugs:
-            continue
-        valid_children = [
-            slug_to_name[slugify(c)]
-            for c in group.children
-            if slugify(c) in valid_slugs and slugify(c) != parent_slug
-        ]
+        parent_display = slug_to_name.get(parent_slug, group.parent)
+
+        valid_children = []
+        for c in group.children:
+            child_slug = slugify(c)
+            if child_slug not in valid_slugs or child_slug == parent_slug:
+                continue
+            if child_slug in seen_child_slugs:
+                continue
+            seen_child_slugs.add(child_slug)
+            valid_children.append(slug_to_name[child_slug])
+
         if valid_children:
             valid_groups.append(
                 GroupSuggestionItem(
-                    parent=slug_to_name[parent_slug],
+                    parent=parent_display,
                     children=valid_children,
                 )
             )

--- a/backend/src/backend/routers/categories.py
+++ b/backend/src/backend/routers/categories.py
@@ -375,7 +375,15 @@ def auto_group_apply(
         parent_slug = slugify(group.parent)
         parent_cat = slug_map.get(parent_slug)
         if not parent_cat:
-            continue
+            # Create new parent category for novel theme names
+            parent_cat = Category(
+                display_name=group.parent,
+                slug=parent_slug,
+                is_seen=True,
+            )
+            session.add(parent_cat)
+            session.flush()
+            slug_map[parent_slug] = parent_cat
 
         moved_in_group = 0
         for child_name in group.children:

--- a/backend/tests/test_auto_group.py
+++ b/backend/tests/test_auto_group.py
@@ -478,9 +478,7 @@ class TestAutoGroupSuggest:
 
         mock_response = GroupingResponse(
             groups=[
-                GroupSuggestion(
-                    parent="Technology", children=["AI", "Programming"]
-                ),
+                GroupSuggestion(parent="Technology", children=["AI", "Programming"]),
             ]
         )
 

--- a/backend/tests/test_auto_group.py
+++ b/backend/tests/test_auto_group.py
@@ -121,11 +121,11 @@ class TestThemeResponse:
         assert resp.themes[0] == "Technology"
 
     def test_theme_response_requires_themes(self):
-        from backend.prompts.grouping import ThemeResponse
-
         import pytest
 
-        with pytest.raises(Exception):
+        from backend.prompts.grouping import ThemeResponse
+
+        with pytest.raises(ValueError):
             ThemeResponse.model_validate({})
 
 

--- a/backend/tests/test_auto_group.py
+++ b/backend/tests/test_auto_group.py
@@ -36,12 +36,14 @@ class TestBuildGroupingPrompt:
         assert "- Programming" in prompt
         assert "- Science" in prompt
 
-    def test_includes_existing_groups(self):
+    def test_includes_existing_groups_with_incomplete_framing(self):
         prompt = build_grouping_prompt(
             ["AI", "Programming", "Technology"],
             {"Technology": ["AI", "Programming"]},
         )
         assert "Technology > AI, Programming" in prompt
+        assert "incomplete" in prompt.lower()
+        assert "not yet assigned" in prompt.lower()
 
     def test_omits_existing_groups_section_when_empty(self):
         prompt = build_grouping_prompt(["AI", "Science"], {})
@@ -67,6 +69,15 @@ class TestBuildGroupingPrompt:
     def test_grouping_response_empty_groups(self):
         resp = GroupingResponse.model_validate({"groups": []})
         assert resp.groups == []
+
+    def test_build_theme_proposal_prompt_includes_all_categories(self):
+        from backend.prompts.grouping import build_theme_proposal_prompt
+
+        prompt = build_theme_proposal_prompt(["AI", "Programming", "Science"])
+        assert "- AI" in prompt
+        assert "- Programming" in prompt
+        assert "- Science" in prompt
+        assert "Current groups" not in prompt  # No anchoring on existing groups
 
 
 # --- Cycle 2: POST /api/categories/auto-group/apply ---

--- a/backend/tests/test_auto_group.py
+++ b/backend/tests/test_auto_group.py
@@ -351,6 +351,39 @@ class TestAutoGroupApply:
         assert ai.parent_id == new_parent.id
         assert prog.parent_id == new_parent.id
 
+    def test_apply_reuses_existing_on_slug_collision(
+        self,
+        test_client: TestClient,
+        test_session: Session,
+        make_category: Callable[..., Category],
+    ):
+        """If LLM returns same slug as existing, reuse existing category."""
+        existing = make_category(display_name="Dev Tools", slug="dev-tools")
+        child1 = make_category(display_name="VS Code", slug="vs-code")
+        child2 = make_category(display_name="Git", slug="git")
+
+        response = test_client.post(
+            "/api/categories/auto-group/apply",
+            json={
+                "groups": [
+                    {"parent": "Dev Tools", "children": ["VS Code", "Git"]},
+                ]
+            },
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["groups_applied"] == 1
+
+        test_session.refresh(child1)
+        test_session.refresh(child2)
+        assert child1.parent_id == existing.id
+        assert child2.parent_id == existing.id
+
+        from sqlmodel import func, select
+
+        count = test_session.exec(select(func.count()).select_from(Category)).one()
+        assert count == 3  # existing + child1 + child2
+
 
 # --- Cycle 4: POST /api/categories/auto-group/suggest ---
 

--- a/backend/tests/test_auto_group.py
+++ b/backend/tests/test_auto_group.py
@@ -79,6 +79,15 @@ class TestBuildGroupingPrompt:
         assert "- Science" in prompt
         assert "Current groups" not in prompt  # No anchoring on existing groups
 
+    def test_build_theme_proposal_prompt_categories_sorted(self):
+        from backend.prompts.grouping import build_theme_proposal_prompt
+
+        prompt = build_theme_proposal_prompt(["Zebra", "Alpha", "Middle"])
+        alpha_pos = prompt.index("- Alpha")
+        middle_pos = prompt.index("- Middle")
+        zebra_pos = prompt.index("- Zebra")
+        assert alpha_pos < middle_pos < zebra_pos
+
 
 # --- Cycle 2: POST /api/categories/auto-group/apply ---
 

--- a/backend/tests/test_auto_group.py
+++ b/backend/tests/test_auto_group.py
@@ -102,6 +102,14 @@ class TestBuildGroupingPrompt:
         # Structural rules carried over
         assert "at least two children" in prompt.lower()
 
+    def test_build_assignment_prompt_no_existing_children(self):
+        from backend.prompts.grouping import build_assignment_prompt
+
+        prompt = build_assignment_prompt(["AI", "Programming"], ["Tech"])
+        # The ">" format is used in build_grouping_prompt for existing group children
+        # Assignment prompt should NOT show pre-existing assignments
+        assert ">" not in prompt or prompt.count(">") == 0
+
 
 # --- Cycle 2: POST /api/categories/auto-group/apply ---
 

--- a/backend/tests/test_auto_group.py
+++ b/backend/tests/test_auto_group.py
@@ -435,3 +435,43 @@ class TestAutoGroupSuggest:
         assert len(body["groups"]) == 1
         assert body["groups"][0]["parent"] == "Technology"
         assert set(body["groups"][0]["children"]) == {"AI", "Programming"}
+
+    def test_suggest_deduplicates_children_across_groups(
+        self,
+        test_client: TestClient,
+        make_category: Callable[..., Category],
+    ):
+        """A child claimed by multiple groups should only appear in the first."""
+        make_category(display_name="AI", slug="ai")
+        make_category(display_name="ML", slug="ml")
+        make_category(display_name="Robotics", slug="robotics")
+
+        mock_response = GroupingResponse(
+            groups=[
+                GroupSuggestion(parent="Tech", children=["AI", "ML"]),
+                GroupSuggestion(parent="Engineering", children=["AI", "Robotics"]),
+            ]
+        )
+
+        with (
+            patch(
+                "backend.routers.categories.resolve_task_runtime",
+                return_value=MOCK_RUNTIME,
+            ),
+            patch("backend.routers.categories.get_provider") as mock_get_provider,
+        ):
+            mock_provider = AsyncMock()
+            mock_provider.suggest_groups.return_value = mock_response
+            mock_get_provider.return_value = mock_provider
+
+            response = test_client.post(
+                "/api/categories/auto-group/suggest",
+                json={},
+            )
+
+        assert response.status_code == 200
+        groups = response.json()["groups"]
+        assert len(groups) == 2
+        assert groups[0]["children"] == ["AI", "ML"]
+        # AI should NOT appear in the second group
+        assert groups[1]["children"] == ["Robotics"]

--- a/backend/tests/test_auto_group.py
+++ b/backend/tests/test_auto_group.py
@@ -111,6 +111,24 @@ class TestBuildGroupingPrompt:
         assert ">" not in prompt or prompt.count(">") == 0
 
 
+class TestThemeResponse:
+    def test_theme_response_schema(self):
+        from backend.prompts.grouping import ThemeResponse
+
+        data = {"themes": ["Technology", "Science", "Culture"]}
+        resp = ThemeResponse.model_validate(data)
+        assert len(resp.themes) == 3
+        assert resp.themes[0] == "Technology"
+
+    def test_theme_response_requires_themes(self):
+        from backend.prompts.grouping import ThemeResponse
+
+        import pytest
+
+        with pytest.raises(Exception):
+            ThemeResponse.model_validate({})
+
+
 # --- Cycle 2: POST /api/categories/auto-group/apply ---
 
 

--- a/backend/tests/test_auto_group.py
+++ b/backend/tests/test_auto_group.py
@@ -259,13 +259,13 @@ class TestAutoGroupApply:
 
     # --- Cycle 3: Edge cases ---
 
-    def test_skips_nonexistent_category_names(
+    def test_creates_new_parent_skips_nonexistent_children(
         self,
         test_client: TestClient,
         test_session: Session,
         make_category: Callable[..., Category],
     ):
-        """Groups referencing non-existent categories are silently skipped."""
+        """Novel parent names create new categories; non-existent children are skipped."""
         real = make_category(display_name="Real", slug="real")
 
         response = test_client.post(
@@ -279,12 +279,12 @@ class TestAutoGroupApply:
         )
         assert response.status_code == 200
         body = response.json()
-        # Neither group could be fully applied
-        assert body["groups_applied"] == 0
-        assert body["categories_moved"] == 0
+        # "Ghost Parent" is created and "Real" moved under it; "Ghost Child" skipped
+        assert body["groups_applied"] == 1
+        assert body["categories_moved"] == 1
 
         test_session.refresh(real)
-        assert real.parent_id is None
+        assert real.parent_id is not None
 
     def test_skips_self_reference(
         self,
@@ -313,6 +313,43 @@ class TestAutoGroupApply:
         test_session.refresh(other)
         assert cat.parent_id is None
         assert other.parent_id == cat.id
+
+    def test_apply_creates_new_parent_category(
+        self,
+        test_client: TestClient,
+        test_session: Session,
+        make_category: Callable[..., Category],
+    ):
+        """Apply with a novel parent name creates a new Category row."""
+        ai = make_category(display_name="AI", slug="ai")
+        prog = make_category(display_name="Programming", slug="programming")
+
+        response = test_client.post(
+            "/api/categories/auto-group/apply",
+            json={
+                "groups": [
+                    {"parent": "Technology", "children": ["AI", "Programming"]},
+                ]
+            },
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["groups_applied"] == 1
+        assert body["categories_moved"] == 2
+
+        from sqlmodel import select
+
+        new_parent = test_session.exec(
+            select(Category).where(Category.slug == "technology")
+        ).first()
+        assert new_parent is not None
+        assert new_parent.display_name == "Technology"
+        assert new_parent.is_seen is True
+
+        test_session.refresh(ai)
+        test_session.refresh(prog)
+        assert ai.parent_id == new_parent.id
+        assert prog.parent_id == new_parent.id
 
 
 # --- Cycle 4: POST /api/categories/auto-group/suggest ---

--- a/backend/tests/test_auto_group.py
+++ b/backend/tests/test_auto_group.py
@@ -395,3 +395,43 @@ class TestAutoGroupSuggest:
             json={},
         )
         assert response.status_code == 400
+
+    def test_suggest_allows_new_parent_names(
+        self,
+        test_client: TestClient,
+        make_category: Callable[..., Category],
+    ):
+        """Groups with novel parent names (not in DB) should pass through."""
+        make_category(display_name="AI", slug="ai")
+        make_category(display_name="Programming", slug="programming")
+        make_category(display_name="Science", slug="science")
+
+        mock_response = GroupingResponse(
+            groups=[
+                GroupSuggestion(
+                    parent="Technology", children=["AI", "Programming"]
+                ),
+            ]
+        )
+
+        with (
+            patch(
+                "backend.routers.categories.resolve_task_runtime",
+                return_value=MOCK_RUNTIME,
+            ),
+            patch("backend.routers.categories.get_provider") as mock_get_provider,
+        ):
+            mock_provider = AsyncMock()
+            mock_provider.suggest_groups.return_value = mock_response
+            mock_get_provider.return_value = mock_provider
+
+            response = test_client.post(
+                "/api/categories/auto-group/suggest",
+                json={},
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body["groups"]) == 1
+        assert body["groups"][0]["parent"] == "Technology"
+        assert set(body["groups"][0]["children"]) == {"AI", "Programming"}

--- a/backend/tests/test_auto_group.py
+++ b/backend/tests/test_auto_group.py
@@ -88,6 +88,20 @@ class TestBuildGroupingPrompt:
         zebra_pos = prompt.index("- Zebra")
         assert alpha_pos < middle_pos < zebra_pos
 
+    def test_build_assignment_prompt_includes_categories_and_themes(self):
+        from backend.prompts.grouping import build_assignment_prompt
+
+        prompt = build_assignment_prompt(
+            ["AI", "Programming", "Science"], ["Technology", "Research"]
+        )
+        assert "- AI" in prompt
+        assert "- Programming" in prompt
+        assert "- Science" in prompt
+        assert "Technology" in prompt
+        assert "Research" in prompt
+        # Structural rules carried over
+        assert "at least two children" in prompt.lower()
+
 
 # --- Cycle 2: POST /api/categories/auto-group/apply ---
 

--- a/backend/tests/test_google_provider.py
+++ b/backend/tests/test_google_provider.py
@@ -221,10 +221,22 @@ async def test_list_models_empty_selected_returns_empty(monkeypatch):
     from backend.llm_providers import google
 
     # Seed the module-level cache with some models
-    monkeypatch.setattr(google, "_model_cache", [
-        {"name": "gemini-2.5-flash", "display_name": "Gemini 2.5 Flash", "description": ""},
-        {"name": "gemini-2.5-pro", "display_name": "Gemini 2.5 Pro", "description": ""},
-    ])
+    monkeypatch.setattr(
+        google,
+        "_model_cache",
+        [
+            {
+                "name": "gemini-2.5-flash",
+                "display_name": "Gemini 2.5 Flash",
+                "description": "",
+            },
+            {
+                "name": "gemini-2.5-pro",
+                "display_name": "Gemini 2.5 Pro",
+                "description": "",
+            },
+        ],
+    )
     monkeypatch.setattr(google, "_model_cache_time", time.time())
 
     provider = GoogleProvider()

--- a/backend/tests/test_provider_two_phase.py
+++ b/backend/tests/test_provider_two_phase.py
@@ -111,3 +111,41 @@ class TestOllamaTwoPhase:
         assert call_count == 2
         assert len(result.groups) == 1
         assert result.groups[0].parent == "Tech"
+
+    @pytest.mark.asyncio
+    async def test_empty_themes_returns_empty_grouping(self):
+        """If Phase 1 returns no themes, short-circuit."""
+        from backend.llm_providers.ollama import OllamaProvider
+
+        provider = OllamaProvider()
+
+        call_count = 0
+
+        async def mock_chat(**kwargs):
+            nonlocal call_count
+            call_count += 1
+
+            async def chunk_gen():
+                yield {"message": {"content": '{"themes": []}'}}
+
+            return chunk_gen()
+
+        mock_client = AsyncMock()
+        mock_client.chat = mock_chat
+
+        with patch(
+            "backend.llm_providers.ollama.get_ollama_client",
+            return_value=mock_client,
+        ):
+            result = await provider.suggest_groups(
+                all_categories=["AI", "ML"],
+                existing_groups={},
+                config=ProviderTaskConfig(
+                    endpoint="http://localhost:11434",
+                    model="test-model",
+                    thinking=False,
+                ),
+            )
+
+        assert call_count == 1
+        assert result.groups == []

--- a/backend/tests/test_provider_two_phase.py
+++ b/backend/tests/test_provider_two_phase.py
@@ -47,3 +47,22 @@ class TestGoogleTwoPhase:
         # Second call should use GroupingResponse schema
         assert mock_gen.call_args_list[1].args[-1] is GroupingResponse
         assert result == grouping_response
+
+    @pytest.mark.asyncio
+    async def test_empty_themes_returns_empty_grouping(self):
+        """If Phase 1 returns no themes, short-circuit with empty groups."""
+        from backend.llm_providers.google import GoogleProvider
+
+        provider = GoogleProvider()
+
+        with patch.object(provider, "_generate", new_callable=AsyncMock) as mock_gen:
+            mock_gen.return_value = ThemeResponse(themes=[])
+
+            result = await provider.suggest_groups(
+                all_categories=["AI", "ML"],
+                existing_groups={},
+                config=MOCK_CONFIG,
+            )
+
+        assert mock_gen.call_count == 1  # Only Phase 1 called
+        assert result.groups == []

--- a/backend/tests/test_provider_two_phase.py
+++ b/backend/tests/test_provider_two_phase.py
@@ -66,3 +66,48 @@ class TestGoogleTwoPhase:
 
         assert mock_gen.call_count == 1  # Only Phase 1 called
         assert result.groups == []
+
+
+class TestOllamaTwoPhase:
+    @pytest.mark.asyncio
+    async def test_suggest_groups_calls_two_phases(self):
+        """suggest_groups should stream twice: ThemeResponse then GroupingResponse."""
+        from backend.llm_providers.ollama import OllamaProvider
+
+        provider = OllamaProvider()
+
+        theme_json = '{"themes": ["Tech", "Science"]}'
+        grouping_json = '{"groups": [{"parent": "Tech", "children": ["AI", "ML"]}]}'
+
+        call_count = 0
+
+        async def mock_chat(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            content = theme_json if call_count == 1 else grouping_json
+
+            async def chunk_gen():
+                yield {"message": {"content": content}}
+
+            return chunk_gen()
+
+        mock_client = AsyncMock()
+        mock_client.chat = mock_chat
+
+        with patch(
+            "backend.llm_providers.ollama.get_ollama_client",
+            return_value=mock_client,
+        ):
+            result = await provider.suggest_groups(
+                all_categories=["AI", "ML", "Biology"],
+                existing_groups={},
+                config=ProviderTaskConfig(
+                    endpoint="http://localhost:11434",
+                    model="test-model",
+                    thinking=False,
+                ),
+            )
+
+        assert call_count == 2
+        assert len(result.groups) == 1
+        assert result.groups[0].parent == "Tech"

--- a/backend/tests/test_provider_two_phase.py
+++ b/backend/tests/test_provider_two_phase.py
@@ -1,0 +1,49 @@
+"""Tests for two-phase suggest_groups in LLM providers."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from backend.llm_providers.base import ProviderTaskConfig
+from backend.prompts.grouping import (
+    GroupingResponse,
+    GroupSuggestion,
+    ThemeResponse,
+)
+
+MOCK_CONFIG = ProviderTaskConfig(
+    endpoint="http://localhost",
+    model="test-model",
+    thinking=False,
+    api_key="test-key",
+)
+
+
+class TestGoogleTwoPhase:
+    @pytest.mark.asyncio
+    async def test_suggest_groups_calls_two_phases(self):
+        """suggest_groups should call _generate twice: ThemeResponse then GroupingResponse."""
+        from backend.llm_providers.google import GoogleProvider
+
+        provider = GoogleProvider()
+
+        theme_response = ThemeResponse(themes=["Tech", "Science"])
+        grouping_response = GroupingResponse(
+            groups=[GroupSuggestion(parent="Tech", children=["AI", "ML"])]
+        )
+
+        with patch.object(provider, "_generate", new_callable=AsyncMock) as mock_gen:
+            mock_gen.side_effect = [theme_response, grouping_response]
+
+            result = await provider.suggest_groups(
+                all_categories=["AI", "ML", "Biology"],
+                existing_groups={},
+                config=MOCK_CONFIG,
+            )
+
+        assert mock_gen.call_count == 2
+        # First call should use ThemeResponse schema
+        assert mock_gen.call_args_list[0].args[-1] is ThemeResponse
+        # Second call should use GroupingResponse schema
+        assert mock_gen.call_args_list[1].args[-1] is GroupingResponse
+        assert result == grouping_response

--- a/docs/plans/2026-04-05-fix-category-grouping-two-phase-plan.md
+++ b/docs/plans/2026-04-05-fix-category-grouping-two-phase-plan.md
@@ -1,0 +1,131 @@
+---
+title: "fix: Two-phase LLM grouping to reduce ungrouped categories (#79)"
+type: fix
+status: draft
+date: 2026-04-05
+issue: 79
+---
+
+# fix: Two-phase LLM grouping to reduce ungrouped categories (#79)
+
+## Problem
+
+The auto-group feature sends all ~200 categories plus existing groups to the LLM in a single call. The model **anchors** on the existing groups — reproducing them verbatim and ignoring 50-110 ungrouped categories. Research confirms this anchoring bias is not fixable with prompt engineering alone.
+
+Categories like Docker, Node.js, CLI, Education, and Sports clearly belong in groups but are consistently left out.
+
+## Solution: Two-Phase Role Separation
+
+Split the single complex task into two simpler tasks:
+
+**Phase 1 — Propose Themes (creative/divergent):**
+- Input: all category names only (no existing groups — avoids anchoring entirely)
+- Task: "What parent themes would organize these categories?"
+- Output: list of theme strings (`ThemeResponse`)
+
+**Phase 2 — Assign Categories (mechanical/convergent):**
+- Input: all category names + the themes from Phase 1
+- Task: "Assign each category to the best-fitting theme"
+- Output: parent→children mapping (`GroupingResponse`)
+
+This works because smaller models handle each sub-task well individually — Flash Lite scores 94% on intent routing (classification) tasks but struggles with combined creative + classification tasks over long lists.
+
+## Decisions
+
+1. **Option C for theme count** — no hard constraint on number of themes. Group size limits are enforced in Phase 2 rules instead.
+2. **No anchoring in Phase 1** — existing groups/parents are NOT passed to the model. It proposes themes purely from the category list. No inter-phase validation of themes either — pass them straight through to Phase 2.
+3. **Existing category names can be parents** — the model may reuse existing categories as parent themes or propose new ones.
+4. **New parents created on apply** — three-tier parent resolution: (a) parent exists as a root category → reuse it, (b) parent exists as a child/ungrouped category → it's already flattened to root by the flatten step, reuse it, (c) completely new name → create a new Category row.
+5. **Self-reference dedup** — already handled at line 383 of the apply endpoint (`child_cat.id == parent_cat.id` skip). No additional work needed.
+6. **Old single-pass prompt preserved** — `build_grouping_prompt` kept for now as fallback; can be removed once two-phase is validated.
+
+## Proposed Changes
+
+### 1. New response schema and prompt builders (`prompts/grouping.py`)
+
+Add:
+- `ThemeResponse` — Pydantic model with `themes: list[str]` (already added)
+- `build_theme_proposal_prompt(all_categories)` — Phase 1 prompt
+- `build_assignment_prompt(all_categories, themes)` — Phase 2 prompt
+
+The Phase 1 prompt should:
+- List all category names
+- No existing groups or parent hints (clean slate to avoid anchoring)
+- Ask for broad, meaningful themes — not one per category
+
+The Phase 2 prompt should:
+- List all category names + the themes from Phase 1
+- Enforce rules: exact child names, min 2 children, 15-20 max per group, no nesting
+- Not show existing group children (avoids anchoring)
+
+### 2. Provider changes (`llm_providers/google.py`, `llm_providers/ollama.py`)
+
+Update `suggest_groups` in both providers to:
+1. Build Phase 1 prompt → call LLM with `ThemeResponse` schema
+2. If Phase 1 returns 0 themes → return empty `GroupingResponse(groups=[])` (everything stays ungrouped)
+3. Build Phase 2 prompt using Phase 1 themes → call LLM with `GroupingResponse` schema
+4. Return the Phase 2 result
+
+The protocol signature stays the same — the two-phase logic is an implementation detail.
+
+### 3. Suggest endpoint validation (`routers/categories.py`)
+
+Current validation rejects parents not found in DB. Update to:
+- Still validate children against DB slugs (must exist)
+- Allow new parent names through (they'll be created on apply)
+- For new parents: use the LLM-returned name as-is in the suggestion response
+- **Deduplicate children across groups** using a `seen_slugs` set (first-assignment-wins), so the preview matches what apply will actually do. If a child appears under two parents, only the first occurrence is kept.
+
+### 4. Apply endpoint — three-tier parent resolution (`routers/categories.py`)
+
+The flatten step already handles case (b) — all categories become roots before regrouping. So the apply loop just needs to handle the "not found" case:
+
+When `slug_map.get(parent_slug)` returns `None`:
+- Check if slugified parent name already exists in `slug_map` (handles slug collisions like "Developer Tools" vs "Dev Tools" → same slug)
+- If collision: reuse existing category as parent
+- If truly new: create a new `Category` row: `display_name` from the group's parent name, `slug` from slugify, `weight=None`, `is_seen=True`
+- Flush to get an ID, add to `slug_map`
+- Continue with normal child assignment
+
+### 5. Tests (`tests/test_auto_group.py`)
+
+New tests:
+- `test_build_theme_proposal_prompt` — includes all category names, no existing groups
+- `test_build_assignment_prompt` — includes categories and themes, enforces rules
+- `test_theme_response_schema` — validates ThemeResponse model
+- `test_suggest_allows_new_parent_names` — new parents pass through validation
+- `test_apply_creates_new_parent_category` — new parent auto-created in DB
+
+Updated tests:
+- `test_suggest_returns_groups` — mock now returns two-phase provider calls
+
+### 6. Frontend dialog fixes (`AutoGroupDialog.tsx`, `CategoriesSection.tsx`)
+
+Three bugs in the current auto-group dialog flow:
+
+**a) Cancel must clear suggestions.** Currently `handleClose` resets dialog-internal state but does NOT clear `autoGroupSuggestions` in the parent (`CategoriesSection`). This means stale suggestions survive across dialog open/close cycles. Fix: call `setAutoGroupSuggestions(null)` when closing without applying (add an `onCancel` callback or clear in `onOpenChange`).
+
+**b) Re-group must preserve provider/model selection.** Currently `handleRegroup` calls `onSuggest()` with no arguments, losing the user's provider/model choice and falling back to the server default. Fix: pass the current `selectedProvider`/`selectedModel` to `onSuggest(options)`.
+
+**c) Reopening always starts from selection.** This is already correct once (a) is fixed — clearing suggestions + resetting `hasTriggered` in `handleClose` means the dialog starts fresh at the provider picker (or auto-triggers for single provider).
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `backend/src/backend/prompts/grouping.py` | Add `ThemeResponse` (done), two prompt builders |
+| `backend/src/backend/llm_providers/base.py` | No change — protocol stays the same |
+| `backend/src/backend/llm_providers/google.py` | Two-phase logic in `suggest_groups` |
+| `backend/src/backend/llm_providers/ollama.py` | Two-phase logic in `suggest_groups` |
+| `backend/src/backend/routers/categories.py` | Allow new parents in suggest + dedup children, create new parents on apply |
+| `backend/tests/test_auto_group.py` | New + updated tests |
+| `frontend/src/components/settings/AutoGroupDialog.tsx` | Fix Re-group to preserve provider/model |
+| `frontend/src/components/settings/CategoriesSection.tsx` | Clear suggestions on cancel |
+
+## Verification
+
+1. `cd backend && uv run pytest tests/test_auto_group.py -v` — all tests pass
+2. `cd backend && uv run ruff check . && uv run ruff format --check .` — clean
+3. `cd frontend && bun run build` — no type errors
+4. Manual: trigger auto-group from UI, compare ungrouped count (target: <30, down from ~85)
+5. Manual: verify cancel clears suggestions, re-group preserves model selection, reopen starts fresh

--- a/frontend/src/components/settings/AutoGroupDialog.tsx
+++ b/frontend/src/components/settings/AutoGroupDialog.tsx
@@ -122,7 +122,10 @@ export function AutoGroupDialog({
   };
 
   const handleRegroup = () => {
-    onSuggest();
+    onSuggest({
+      ...(selectedProvider && { provider: selectedProvider }),
+      ...(selectedModel && { model: selectedModel }),
+    });
   };
 
   // --- Render phases ---

--- a/frontend/src/components/settings/CategoriesSection.tsx
+++ b/frontend/src/components/settings/CategoriesSection.tsx
@@ -275,7 +275,10 @@ export function CategoriesSection() {
 
         <AutoGroupDialog
           open={autoGroupOpen}
-          onOpenChange={setAutoGroupOpen}
+          onOpenChange={(open) => {
+            setAutoGroupOpen(open);
+            if (!open) setAutoGroupSuggestions(null);
+          }}
           onSuggest={(options) =>
             autoGroupSuggestMutation.mutate(options, {
               onSuccess: (data) => setAutoGroupSuggestions(data.groups),


### PR DESCRIPTION
# fix: Two-phase LLM grouping to reduce ungrouped categories

## What is this PR about?

Replaces the single-pass LLM category grouping with a two-phase approach: first propose themes, then assign categories to themes. This eliminates the anchoring bias that caused the model to reproduce existing groups verbatim and ignore 50-110 categories.

## Why is this change needed?

The auto-group feature left ~85 categories ungrouped because the LLM anchored on existing groups passed as context. Categories like Docker, Node.js, CLI, and Education were consistently missed despite clearly belonging in groups.

## How is this change implemented?

- Phase 1 prompt asks the LLM to propose parent theme names from scratch (no existing groups shown, avoids anchoring)
- Phase 2 prompt asks the LLM to assign each category to the best-fitting theme (simple classification task)
- Few-shot examples in both prompts teach the model how to split broad domains and assign aggressively
- Apply endpoint now creates new parent Category rows for novel theme names proposed by the LLM
- Suggest endpoint deduplicates children across groups so preview matches apply behavior
- Frontend dialog fixes: cancel clears suggestions, re-group preserves provider/model selection

## How to test this change?

1. Open Settings → Categories → click Auto-Group
2. Select a provider/model and generate groupings
3. Verify most categories are assigned to groups (~25 or fewer ungrouped, down from ~85)
4. Verify cancel discards suggestions and reopening starts fresh
5. Verify re-group preserves the selected provider/model
6. Apply groupings and verify new parent categories are created in the sidebar

## Notes

- The old single-pass prompt (`build_grouping_prompt`) is preserved as fallback but no longer called by providers
- Two LLM calls per grouping run instead of one — still cheap on Flash Lite
- Reviewed with Codex sparring partner; slug collision guard added based on that review

Fixes #79