### PR TITLE
v2: categorization — closed vocabulary + single proposal channel (#90)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,6 +20,10 @@ _Avoid_: hidden, banned, excluded
 A remembered former category name that deterministically resolves future LLM proposals to a surviving category (or to discard). Created when categories are merged or renamed; prevents deleted junk from being recreated.
 _Avoid_: synonym list, tombstone
 
+**Proposal**:
+The single channel by which the categorization LLM nominates a category name when nothing in the vocabulary fits — at most one per article. Proposals resolve through aliases before anything is created; a surviving proposal becomes a live category flagged for triage.
+_Avoid_: suggestion, suggested category
+
 **Category triage**:
 Reviewing LLM-created categories after the fact — keep, rename, merge, or suppress. New categories are live and usable from the moment of creation; triage is cleanup, never a approval gate.
 _Avoid_: category approval, moderation queue

--- a/backend/src/backend/database.py
+++ b/backend/src/backend/database.py
@@ -38,6 +38,19 @@ def set_sqlite_pragma(dbapi_conn, connection_record):
     cursor.close()
 
 
+# Default category hierarchy for new installs (parent -> children)
+DEFAULT_CATEGORY_HIERARCHY: dict[str, list[str]] = {
+    "Technology": ["Cybersecurity", "AI", "Programming"],
+    "Science": ["Climate", "Space"],
+    "Business": ["Finance", "Startups"],
+    "Entertainment": ["Gaming", "Film", "Music"],
+    "Culture": ["Philosophy", "History", "Design"],
+    "Health": [],
+    "Politics": ["Law"],
+    "Education": [],
+}
+
+
 # --- Smart casing helpers ---
 
 SMART_CASE_MAP = {
@@ -113,7 +126,6 @@ def _seed_default_categories(conn):
     Only runs on fresh installs (empty categories table).
     """
     from backend.models import Category
-    from backend.prompts import DEFAULT_CATEGORY_HIERARCHY
 
     count = conn.execute(text("SELECT COUNT(*) FROM categories")).scalar()
     if count:

--- a/backend/src/backend/prompts/__init__.py
+++ b/backend/src/backend/prompts/__init__.py
@@ -1,10 +1,10 @@
 """LLM prompt templates and response schemas for content curation."""
 
 from backend.prompts.categorization import (
-    DEFAULT_CATEGORY_HIERARCHY,
     ArticleCategoryResult,
     BatchCategoryResponse,
     build_batch_categorization_prompt,
+    build_categorization_schema,
 )
 from backend.prompts.grouping import (
     GroupingResponse,
@@ -22,10 +22,10 @@ __all__ = [
     "ArticleScoringResult",
     "BatchCategoryResponse",
     "BatchScoringResponse",
-    "DEFAULT_CATEGORY_HIERARCHY",
     "GroupSuggestion",
     "GroupingResponse",
     "build_batch_categorization_prompt",
     "build_batch_scoring_prompt",
+    "build_categorization_schema",
     "build_grouping_prompt",
 ]

--- a/backend/src/backend/prompts/categorization.py
+++ b/backend/src/backend/prompts/categorization.py
@@ -77,9 +77,9 @@ def build_batch_categorization_prompt(
 1. ONLY categorize each article's PRIMARY topics — what the article is fundamentally about.
 2. IGNORE incidental mentions, anecdotes, metaphors, and examples used to illustrate a point.
 3. Assign ONLY categories from the vocabulary below. Maximum 4 per article; fewer is better.
-4. Use `proposed_category` ONLY when NOTHING in the vocabulary fits the article's primary topic AND that topic is likely to recur across many articles. Otherwise set it to null.
-5. Propose at most ONE new category per article. Proposed names must be human-readable English (e.g., "Artificial Intelligence", "Web Development", "Open Source"). Do NOT use kebab-case, underscores, or slashes. Even if the article is in another language, always use English names.
-6. Keep proposals BROAD. Use "AI" not "AI-Assisted Programming" or "Generative AI". Use "Programming" not "Python Development".
+4. Prefer the most specific fitting category in the vocabulary. Use `proposed_category` when the article's primary topic is meaningfully more specific than the best-fitting existing category AND that topic is likely to recur across many articles (e.g., if articles about cooking are only covered by "Culture", propose "Food"). Set it to null when an existing category already captures the topic well.
+5. Propose at most ONE new category per article. Proposed names must be human-readable English. Do NOT use kebab-case, underscores, or slashes. Even if the article is in another language, always use English names.
+6. Keep proposals at recurring-topic breadth, not niche specificity. Use "Food" not "Sourdough Baking". Use "Programming" not "Python Development".
 
 **Category vocabulary:** {categories_list}
 

--- a/backend/src/backend/prompts/categorization.py
+++ b/backend/src/backend/prompts/categorization.py
@@ -5,28 +5,21 @@ of JSON-schema constraint keywords (maxItems, minimum, ...) that strict mode
 may reject — limits are enforced by the prompt and clamped in the worker.
 """
 
-from pydantic import BaseModel
+from typing import Literal
 
-# Default category hierarchy for new installs (parent -> children)
-DEFAULT_CATEGORY_HIERARCHY: dict[str, list[str]] = {
-    "Technology": ["Cybersecurity", "AI", "Programming"],
-    "Science": ["Climate", "Space"],
-    "Business": ["Finance", "Startups"],
-    "Entertainment": ["Gaming", "Film", "Music"],
-    "Culture": ["Philosophy", "History", "Design"],
-    "Health": [],
-    "Politics": ["Law"],
-    "Education": [],
-}
+from pydantic import BaseModel, create_model
 
 
 class ArticleCategoryResult(BaseModel):
-    """Single article result within a batch categorization response."""
+    """Single article result within a batch categorization response.
+
+    Static empty-vocabulary base (ADR-0006): `categories` degrades to
+    list[str] when there are no display names to enumerate.
+    """
 
     article_id: int
     categories: list[str]
-    suggested_new: list[str]
-    suggested_parent: str | None
+    proposed_category: str | None
 
 
 class BatchCategoryResponse(BaseModel):
@@ -35,54 +28,60 @@ class BatchCategoryResponse(BaseModel):
     results: list[ArticleCategoryResult]
 
 
+def build_categorization_schema(
+    display_names: list[str],
+) -> type[BatchCategoryResponse]:
+    """Build the per-batch categorization response schema (ADR-0006).
+
+    With a non-empty vocabulary, `categories` is list[Literal[*display_names]]
+    so out-of-vocabulary assignment is unrepresentable at generation time.
+    An empty vocabulary falls back to the static list[str] base so the batch
+    degrades instead of deadlocking; proposals rebuild the vocabulary.
+    """
+    if not display_names:
+        return BatchCategoryResponse
+
+    category_enum = Literal[tuple(display_names)]  # pyright: ignore[reportInvalidTypeArguments]
+    result_model = create_model(
+        "ArticleCategoryResult",
+        __base__=ArticleCategoryResult,
+        categories=(list[category_enum], ...),  # pyright: ignore[reportInvalidTypeForm]
+    )
+    return create_model(
+        "BatchCategoryResponse",
+        __base__=BatchCategoryResponse,
+        results=(list[result_model], ...),
+    )
+
+
 def build_batch_categorization_prompt(
     articles: list[dict],
     existing_categories: list[str],
-    category_hierarchy: dict[str, list[str]] | None = None,
 ) -> tuple[str, str]:
     """Build system prompt and user message for batch categorization.
 
     Args:
         articles: List of dicts with keys: id, title, content_markdown
-        existing_categories: List of known categories to reuse
-        category_hierarchy: Optional parent->children hierarchy
+        existing_categories: The category vocabulary (display names)
 
     Returns:
         Tuple of (system_prompt, user_message)
     """
     from backend.prompts.content import CATEGORIZATION_MAX_CHARS, format_articles_block
 
-    # Format existing categories
     categories_list = ", ".join(sorted(existing_categories))
-
-    # Format hierarchy if provided
-    hierarchy_section = ""
-    if category_hierarchy:
-        hierarchy_lines = []
-        for parent, children in sorted(category_hierarchy.items()):
-            if children:
-                children_str = ", ".join(children)
-                hierarchy_lines.append(f"{parent} > {children_str}")
-        if hierarchy_lines:
-            hierarchy_section = (
-                "\n\n**Category hierarchy "
-                "(assign new categories as children of these parents when appropriate):**\n"
-                + "\n".join(hierarchy_lines)
-            )
 
     system_prompt = f"""Categorize articles into 1-4 topic categories each.
 
 **Rules (follow strictly):**
 1. ONLY categorize each article's PRIMARY topics — what the article is fundamentally about.
 2. IGNORE incidental mentions, anecdotes, metaphors, and examples used to illustrate a point.
-3. REUSE existing categories from the list below. Strongly prefer existing categories.
-4. Category names should be human-readable English (e.g., "Artificial Intelligence", "Web Development", "Open Source"). Do NOT use kebab-case, underscores, or slashes. Even if the article is in another language, always use English category names.
-5. Keep categories BROAD. Use "AI" not "AI-Assisted Programming" or "Generative AI". Use "Programming" not "Python Development".
-6. Only suggest a new category (max 2, in suggested_new) if NO existing category covers the article's primary topic AND the topic is likely to recur across many articles. Otherwise leave suggested_new empty.
-7. Maximum 4 categories per article. Fewer is better.
-8. When suggesting a new category, suggest which existing parent it should belong under in the suggested_parent field (or null).
+3. Assign ONLY categories from the vocabulary below. Maximum 4 per article; fewer is better.
+4. Use `proposed_category` ONLY when NOTHING in the vocabulary fits the article's primary topic AND that topic is likely to recur across many articles. Otherwise set it to null.
+5. Propose at most ONE new category per article. Proposed names must be human-readable English (e.g., "Artificial Intelligence", "Web Development", "Open Source"). Do NOT use kebab-case, underscores, or slashes. Even if the article is in another language, always use English names.
+6. Keep proposals BROAD. Use "AI" not "AI-Assisted Programming" or "Generative AI". Use "Programming" not "Python Development".
 
-**Existing categories:** {categories_list}{hierarchy_section}
+**Category vocabulary:** {categories_list}
 
 You will receive multiple articles wrapped in `<article>` tags. Return a JSON object with a `results` array. Each entry must include the `article_id` from the input."""
 

--- a/backend/src/backend/routers/categories.py
+++ b/backend/src/backend/routers/categories.py
@@ -252,9 +252,10 @@ async def auto_group_suggest(
     session: Session = Depends(get_session),
 ):
     """Ask LLM to suggest category groupings. No DB writes."""
-    from backend.scoring import get_active_categories
+    from backend.scoring import get_active_categories, get_category_hierarchy
 
-    display_names, hierarchy = get_active_categories(session)
+    display_names = get_active_categories(session)
+    hierarchy = get_category_hierarchy(session)
 
     if len(display_names) < 2:
         raise HTTPException(

--- a/backend/src/backend/scoring.py
+++ b/backend/src/backend/scoring.py
@@ -1,12 +1,13 @@
 """Scoring domain logic: composite scores, blocking, category helpers."""
 
 import logging
+from collections.abc import Sequence
 
 from slugify import slugify
 from sqlmodel import Session, select
 
 from backend.database import smart_case
-from backend.models import Category
+from backend.models import Category, CategoryAlias
 
 logger = logging.getLogger(__name__)
 
@@ -21,42 +22,45 @@ WEIGHT_MULTIPLIERS = {
 }
 
 
-def get_or_create_category(
-    session: Session,
-    display_name: str,
-    suggested_parent: str | None = None,
-) -> Category:
-    """Find existing category by slug, or create new one flagged for triage.
+def resolve_proposal(session: Session, proposed_name: str) -> Category | None:
+    """Resolve a proposed category name through the proposal ladder (ADR-0001).
 
-    Args:
-        session: Database session
-        display_name: Human-readable category name
-        suggested_parent: Optional parent category display name for new categories
+    slugify(proposed_name), then:
+    1. Active category with that slug -> return it (no new row).
+    2. CategoryAlias match -> target set: return the target category;
+       target NULL: return None (discard — deleted junk stays dead).
+    3. Otherwise create a normal-weight category flagged for triage.
 
-    Returns:
-        Existing or newly created Category
+    New categories are born ungrouped — parent_id is never set here
+    (shelving belongs to auto-grouping and triage).
     """
-    slug = slugify(display_name)
+    slug = slugify(proposed_name)
+
     category = session.exec(select(Category).where(Category.slug == slug)).first()
     if category:
         return category
 
-    # Create new category, live immediately but flagged for user triage
+    alias = session.exec(
+        select(CategoryAlias).where(CategoryAlias.alias_slug == slug)
+    ).first()
+    if alias:
+        if alias.target_id is None:
+            return None
+        target = session.get(Category, alias.target_id)
+        if target is None:
+            logger.warning(
+                "Alias %r points at missing category id %s; treating as discard",
+                slug,
+                alias.target_id,
+            )
+        return target
+
     category = Category(
-        display_name=smart_case(display_name),
+        display_name=smart_case(proposed_name),
         slug=slug,
+        weight="normal",
         needs_triage=True,
     )
-
-    # Resolve parent if suggested
-    if suggested_parent:
-        parent_slug = slugify(suggested_parent)
-        parent = session.exec(
-            select(Category).where(Category.slug == parent_slug)
-        ).first()
-        if parent:
-            category.parent_id = parent.id
-
     session.add(category)
     return category
 
@@ -101,25 +105,30 @@ def is_blocked(categories: list[Category]) -> bool:
     return any(category.weight == "block" for category in categories)
 
 
-def get_active_categories(
-    session: Session,
-) -> tuple[list[str], dict[str, list[str]] | None]:
-    """Get the full category vocabulary and its display hierarchy.
+def load_categories(session: Session) -> Sequence[Category]:
+    """Single load point for the category vocabulary, so future filters
+    apply everywhere at once."""
+    return session.exec(select(Category)).all()
+
+
+def get_active_categories(session: Session) -> list[str]:
+    """Get the full category vocabulary as a sorted display-name list.
 
     Blocked categories stay in the vocabulary — blocking suppresses
     articles, never labels (ADR-0001).
-
-    Returns:
-        Tuple of (sorted display name list, category hierarchy dict or None)
     """
-    categories = session.exec(select(Category)).all()
+    categories = load_categories(session)
+    return sorted([cat.display_name for cat in categories], key=str.lower)
 
-    display_names = sorted(
-        [cat.display_name for cat in categories],
-        key=str.lower,
-    )
 
-    # Build hierarchy from parent-child relationships
+def get_category_hierarchy(session: Session) -> dict[str, list[str]] | None:
+    """Get the display hierarchy (parent display name -> sorted child names).
+
+    Groups are display-only shelves — never serialized into the
+    categorization prompt (ADR-0001). Returns None when no groups exist.
+    """
+    categories = load_categories(session)
+
     hierarchy: dict[str, list[str]] = {}
     for cat in categories:
         if cat.parent_id is not None and cat.parent is not None:
@@ -128,4 +137,4 @@ def get_active_categories(
     for children in hierarchy.values():
         children.sort(key=str.lower)
 
-    return display_names, hierarchy if hierarchy else None
+    return hierarchy if hierarchy else None

--- a/backend/src/backend/scoring_queue.py
+++ b/backend/src/backend/scoring_queue.py
@@ -23,16 +23,16 @@ from backend.llm_client import (
 )
 from backend.models import Article, ArticleCategoryLink, Category, UserPreferences
 from backend.prompts import (
-    BatchCategoryResponse,
     BatchScoringResponse,
     build_batch_categorization_prompt,
     build_batch_scoring_prompt,
+    build_categorization_schema,
 )
 from backend.scoring import (
     compute_composite_score,
-    get_active_categories,
-    get_or_create_category,
     is_blocked,
+    load_categories,
+    resolve_proposal,
 )
 
 logger = logging.getLogger(__name__)
@@ -247,13 +247,17 @@ class CategorizationWorker:
                 }
             )
 
-        active_categories, category_hierarchy = get_active_categories(session)
+        # Build the vocabulary once per batch: the lookup map plus the sorted
+        # display-name list the prompt and per-batch enum schema share.
+        all_categories = load_categories(session)
+        by_display: dict[str, Category] = {c.display_name: c for c in all_categories}
+        display_names = sorted(by_display.keys(), key=str.lower)
 
         system_prompt, user_message = build_batch_categorization_prompt(
             article_dicts,
-            active_categories,
-            category_hierarchy=category_hierarchy,
+            display_names,
         )
+        response_schema = build_categorization_schema(display_names)
 
         def _requeue_batch(count_attempt: bool) -> None:
             for art in needs_cat_articles:
@@ -271,7 +275,7 @@ class CategorizationWorker:
                 TASK_CATEGORIZATION,
                 system_prompt,
                 user_message,
-                BatchCategoryResponse,
+                response_schema,
             )
 
             # Build result map, dropping hallucinated IDs
@@ -287,29 +291,48 @@ class CategorizationWorker:
                     dropped,
                 )
 
-            # Resolve categories, creating new ones flagged for triage
+            # Map assigned names through the vocabulary; a miss is dropped,
+            # never created (empty-vocab fallback path + defense-in-depth if
+            # strict mode ever leaks an out-of-enum string, ADR-0006).
             categories_by_article: dict[int, list[Category]] = {
                 aid: [] for aid in batch_ids
             }
 
-            seen_slugs: dict[str, Category] = {}
+            # Per-batch proposal cache: every proposal outcome (existing
+            # category, alias survivor, discard, new row) resolves once per
+            # batch through resolve_proposal. None caches a discard.
+            resolved_proposals: dict[str, Category | None] = {}
             with session.no_autoflush:
                 for aid, categorization in cat_result_map.items():
+                    assigned: list[Category] = []
+                    assigned_slugs: set[str] = set()
                     for cat_name in categorization.categories:
-                        slug = slugify(cat_name)
-                        if slug not in seen_slugs:
-                            seen_slugs[slug] = get_or_create_category(session, cat_name)
-                        categories_by_article[aid].append(seen_slugs[slug])
-
-                    for cat_name in categorization.suggested_new:
-                        slug = slugify(cat_name)
-                        if slug not in seen_slugs:
-                            seen_slugs[slug] = get_or_create_category(
-                                session,
+                        category = by_display.get(cat_name)
+                        if category is None:
+                            logger.warning(
+                                "Article %s: category %r not in vocabulary; dropped",
+                                aid,
                                 cat_name,
-                                suggested_parent=categorization.suggested_parent,
                             )
-                        categories_by_article[aid].append(seen_slugs[slug])
+                            continue
+                        if category.slug not in assigned_slugs:
+                            assigned_slugs.add(category.slug)
+                            assigned.append(category)
+
+                    # New categories enter ONLY through the proposal channel
+                    proposed = categorization.proposed_category
+                    if proposed is not None:
+                        slug = slugify(proposed)
+                        if slug in resolved_proposals:
+                            resolved = resolved_proposals[slug]
+                        else:
+                            resolved = resolve_proposal(session, proposed)
+                            resolved_proposals[slug] = resolved
+                        if resolved is not None and resolved.slug not in assigned_slugs:
+                            assigned_slugs.add(resolved.slug)
+                            assigned.append(resolved)
+
+                    categories_by_article[aid] = assigned
 
             session.commit()  # persist new categories, get IDs
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -14,16 +14,11 @@ from sqlalchemy.pool import StaticPool
 from sqlmodel import Session, SQLModel, create_engine
 
 from backend.config import LLMTaskConfig
-from backend.deps import get_session
+from backend.deps import TASK_CATEGORIZATION, TASK_SCORING, get_session
 from backend.llm_client import LLMNotConfigured
 from backend.main import app
 from backend.models import Article, Category, Feed
-from backend.prompts import (
-    ArticleCategoryResult,
-    ArticleScoringResult,
-    BatchCategoryResponse,
-    BatchScoringResponse,
-)
+from backend.prompts.categorization import ArticleCategoryResult
 
 
 @pytest.fixture(name="test_engine")
@@ -119,12 +114,37 @@ def make_category_fixture(test_session: Session):
     return _make
 
 
+@pytest.fixture(name="cat_result")
+def cat_result_fixture():
+    """Builder for per-article categorization results in canned responses."""
+
+    def _make(
+        article_id: int,
+        categories: list[str] | None = None,
+        proposed: str | None = None,
+    ) -> ArticleCategoryResult:
+        return ArticleCategoryResult(
+            article_id=article_id,
+            categories=categories or [],
+            proposed_category=proposed,
+        )
+
+    return _make
+
+
 class FakeLLMClient:
     """Canned typed responses standing in for the Azure wrapper.
 
     The wrapper is the single test seam (issue #89): queue an object to
     return it, queue an exception to raise it. With nothing queued, one
     plausible result is generated per article id found in the user message.
+
+    Dispatch is keyed on the ``task`` argument ("categorization" vs
+    "scoring"), NOT on the response schema — the categorization schema is
+    built dynamically per batch (ADR-0006), so schema identity is unstable.
+    Canned default results are built by validating plain dicts through the
+    per-batch ``response_schema`` the worker hands us, so every worker test
+    also exercises the real enum.
     """
 
     def __init__(self):
@@ -137,6 +157,10 @@ class FakeLLMClient:
     def queue(self, task: str, item) -> None:
         """Queue a canned response (or exception) for the next call of a task."""
         self.queued.setdefault(task, []).append(item)
+
+    def tasks_invoked(self) -> list[str]:
+        """Tasks that have been called on the wrapper, in call order."""
+        return [call["task"] for call in self.calls]
 
     # --- wrapper interface ---
 
@@ -177,30 +201,29 @@ class FakeLLMClient:
             return item
 
         ids = [int(m) for m in re.findall(r"<article id:(\d+)>", user_message)]
-        if response_schema is BatchCategoryResponse:
-            return BatchCategoryResponse(
-                results=[
-                    ArticleCategoryResult(
-                        article_id=i,
-                        categories=["Technology"],
-                        suggested_new=[],
-                        suggested_parent=None,
-                    )
-                    for i in ids
-                ]
-            )
-        if response_schema is BatchScoringResponse:
-            return BatchScoringResponse(
-                results=[
-                    ArticleScoringResult(
-                        article_id=i,
-                        interest_score=7,
-                        quality_score=8,
-                        reasoning="test",
-                    )
-                    for i in ids
-                ]
-            )
+
+        # Built-in plausible default per task, validated through the per-batch
+        # schema so the real enum is exercised. The categorization default
+        # proposes "Technology" (no enum assignment) — under the closed
+        # vocabulary a bare enum label the worker doesn't know would be
+        # dropped, so bootstrapping flows through the proposal channel.
+        if task == TASK_CATEGORIZATION:
+            results = [
+                {"article_id": i, "categories": [], "proposed_category": "Technology"}
+                for i in ids
+            ]
+            return response_schema.model_validate({"results": results})
+        if task == TASK_SCORING:
+            results = [
+                {
+                    "article_id": i,
+                    "interest_score": 7,
+                    "quality_score": 8,
+                    "reasoning": "test",
+                }
+                for i in ids
+            ]
+            return response_schema.model_validate({"results": results})
         raise AssertionError(
             f"No canned response queued for task '{task}' ({response_schema})"
         )

--- a/backend/tests/test_batch_models.py
+++ b/backend/tests/test_batch_models.py
@@ -1,6 +1,10 @@
 """Tests for batch response models used as Azure structured-output schemas."""
 
-from backend.prompts.categorization import ArticleCategoryResult, BatchCategoryResponse
+from backend.prompts.categorization import (
+    ArticleCategoryResult,
+    BatchCategoryResponse,
+    build_categorization_schema,
+)
 from backend.prompts.grouping import GroupingResponse
 from backend.prompts.scoring import ArticleScoringResult, BatchScoringResponse
 
@@ -10,12 +14,11 @@ class TestArticleCategoryResult:
         result = ArticleCategoryResult(
             article_id=42,
             categories=["Technology", "AI"],
-            suggested_new=["Robotics"],
-            suggested_parent=None,
+            proposed_category="Robotics",
         )
         assert result.article_id == 42
         assert result.categories == ["Technology", "AI"]
-        assert result.suggested_new == ["Robotics"]
+        assert result.proposed_category == "Robotics"
 
 
 class TestBatchCategoryResponse:
@@ -25,21 +28,19 @@ class TestBatchCategoryResponse:
                 {
                     "article_id": 1,
                     "categories": ["Tech"],
-                    "suggested_new": [],
-                    "suggested_parent": None,
+                    "proposed_category": None,
                 },
                 {
                     "article_id": 2,
                     "categories": ["Science"],
-                    "suggested_new": ["Quantum"],
-                    "suggested_parent": "Science",
+                    "proposed_category": "Quantum",
                 },
             ]
         }
         resp = BatchCategoryResponse.model_validate(data)
         assert len(resp.results) == 2
         assert resp.results[0].article_id == 1
-        assert resp.results[1].suggested_new == ["Quantum"]
+        assert resp.results[1].proposed_category == "Quantum"
 
 
 class TestArticleScoringResult:
@@ -115,6 +116,11 @@ class TestStrictSchemaCompatibility:
 
     def test_batch_category_schema_is_strict_compatible(self):
         self._assert_clean(BatchCategoryResponse)
+
+    def test_dynamic_category_schema_is_strict_compatible(self):
+        # The per-batch enum schema must also stay free of constraint keywords.
+        schema = build_categorization_schema(["AI", "Programming"])
+        self._assert_clean(schema)
 
     def test_grouping_schema_is_strict_compatible(self):
         self._assert_clean(GroupingResponse)

--- a/backend/tests/test_batch_prompts.py
+++ b/backend/tests/test_batch_prompts.py
@@ -49,15 +49,6 @@ class TestBuildBatchCategorizationPrompt:
         assert "AI Advances" in user_message
         assert "Climate Report" in user_message
 
-    def test_hierarchy_included_when_provided(self):
-        hierarchy = {"Technology": ["AI", "Programming"]}
-        system_prompt, _ = build_batch_categorization_prompt(
-            articles=SAMPLE_ARTICLES,
-            existing_categories=EXISTING_CATEGORIES,
-            category_hierarchy=hierarchy,
-        )
-        assert "Technology > AI, Programming" in system_prompt
-
 
 class TestBuildBatchScoringPrompt:
     def test_returns_tuple(self):

--- a/backend/tests/test_categorization_api.py
+++ b/backend/tests/test_categorization_api.py
@@ -1,0 +1,81 @@
+"""API-seam tests for issue #90: proposal surfacing and the blocked view.
+
+Drive categorization via the worker, then observe results through the REST
+API against a real SQLite database.
+"""
+
+import pytest
+
+from backend.prompts import BatchCategoryResponse
+from backend.scoring_queue import CategorizationWorker, ScoringWorker
+
+# ---------------------------------------------------------------------------
+# Case 12: a created proposal surfaces via GET /api/categories with triage flag
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_proposal_surfaces_in_categories_api(
+    test_client, test_session, sample_feed, fake_llm, make_article, cat_result
+):
+    article = make_article(
+        sample_feed.id, categorization_state="queued", scoring_state="unscored"
+    )
+    fake_llm.queue(
+        "categorization",
+        BatchCategoryResponse(
+            results=[cat_result(article.id, [], proposed="Retro Computing")]
+        ),
+    )
+
+    await CategorizationWorker().process_next_batch(test_session, batch_size=1)
+    test_session.expire_all()
+
+    categories = test_client.get("/api/categories").json()
+    by_slug = {c["slug"]: c for c in categories}
+    assert "retro-computing" in by_slug
+    created = by_slug["retro-computing"]
+    assert created["needs_triage"] is True
+    assert created["display_name"] == "Retro Computing"
+    assert created["article_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Case 13: a blocked article shows in the blocked view with score 0 + reasoning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_blocked_article_in_blocked_view_with_reasoning(
+    test_client,
+    test_session,
+    sample_feed,
+    fake_llm,
+    make_article,
+    make_category,
+    cat_result,
+):
+    make_category(display_name="Crypto", slug="crypto", weight="block")
+    article = make_article(
+        sample_feed.id, categorization_state="queued", scoring_state="unscored"
+    )
+    fake_llm.queue(
+        "categorization",
+        BatchCategoryResponse(results=[cat_result(article.id, ["Crypto"])]),
+    )
+
+    await CategorizationWorker().process_next_batch(test_session, batch_size=1)
+    await ScoringWorker().process_next_batch(test_session, batch_size=5)
+    test_session.expire_all()
+
+    # Hidden from the default list.
+    assert test_client.get("/api/articles").json() == []
+
+    blocked = test_client.get(
+        "/api/articles", params={"scoring_state": "blocked"}
+    ).json()
+    assert len(blocked) == 1
+    item = blocked[0]
+    assert item["id"] == article.id
+    assert item["composite_score"] == 0.0
+    assert "Crypto" in (item["score_reasoning"] or "")

--- a/backend/tests/test_categorization_proposals.py
+++ b/backend/tests/test_categorization_proposals.py
@@ -1,0 +1,385 @@
+"""Worker-seam tests for the closed-vocabulary categorization contract.
+
+Issue #90 / ADR-0001 / ADR-0006. Real temp SQLite via the shared fixtures,
+Azure wrapper faked. Covers the handoff, the blocked short-circuit, and the
+proposal ladder (active match -> alias survivor -> alias discard -> create).
+
+Enum-category names route through a vocabulary lookup: a miss is logged and
+dropped, NEVER created. New categories enter ONLY through the single
+`proposed_category` channel, resolved via `resolve_proposal`.
+"""
+
+import pytest
+from sqlmodel import select
+
+from backend.models import Article, ArticleCategoryLink, Category, CategoryAlias
+from backend.prompts import ArticleCategoryResult, BatchCategoryResponse
+from backend.scoring import resolve_proposal
+from backend.scoring_queue import CategorizationWorker, ScoringWorker
+
+
+def _links_for(session, article_id: int) -> list[Category]:
+    rows = session.exec(
+        select(Category)
+        .join(ArticleCategoryLink, ArticleCategoryLink.category_id == Category.id)
+        .where(ArticleCategoryLink.article_id == article_id)
+    ).all()
+    return list(rows)
+
+
+# ---------------------------------------------------------------------------
+# Case 4: handoff
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handoff_categorized_and_routed_to_scoring(
+    test_session, sample_feed, fake_llm, make_article
+):
+    a1 = make_article(
+        sample_feed.id, categorization_state="queued", scoring_state="unscored"
+    )
+    a2 = make_article(
+        sample_feed.id, categorization_state="queued", scoring_state="unscored"
+    )
+
+    worker = CategorizationWorker()
+    processed = await worker.process_next_batch(test_session, batch_size=5)
+    assert processed == 2
+
+    test_session.expire_all()
+    for art in (test_session.get(Article, a1.id), test_session.get(Article, a2.id)):
+        assert art.categorization_state == "categorized"
+        assert art.scoring_state == "queued"
+
+    # The built-in default proposes "Technology"; both articles get a link.
+    links = test_session.exec(select(ArticleCategoryLink)).all()
+    assert {link.article_id for link in links} == {a1.id, a2.id}
+
+
+# ---------------------------------------------------------------------------
+# Case 5: blocked short-circuit never calls the scoring LLM
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_blocked_short_circuit_skips_scoring_llm(
+    test_session, sample_feed, fake_llm, make_article, make_category, cat_result
+):
+    make_category(display_name="Crypto", slug="crypto", weight="block")
+    article = make_article(
+        sample_feed.id, categorization_state="queued", scoring_state="unscored"
+    )
+
+    fake_llm.queue(
+        "categorization",
+        BatchCategoryResponse(results=[cat_result(article.id, ["Crypto"])]),
+    )
+
+    await CategorizationWorker().process_next_batch(test_session, batch_size=1)
+    # Run the scoring worker's poll: a blocked article must not be picked up.
+    await ScoringWorker().process_next_batch(test_session, batch_size=5)
+
+    test_session.expire_all()
+    updated = test_session.get(Article, article.id)
+    assert updated.scoring_state == "blocked"
+    assert updated.composite_score == 0.0
+    assert "Crypto" in (updated.score_reasoning or "")
+    assert updated.scored_at is not None
+
+    # The scoring task was never invoked on the wrapper.
+    assert "scoring" not in fake_llm.tasks_invoked()
+
+
+# ---------------------------------------------------------------------------
+# Case 5b: a blocked category reached via the proposal channel also blocks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_blocked_category_via_proposal_blocks_article(
+    test_session, sample_feed, fake_llm, make_article, make_category, cat_result
+):
+    make_category(display_name="Crypto", slug="crypto", weight="block")
+    make_category(display_name="AI", slug="ai", weight="normal")
+    article = make_article(
+        sample_feed.id, categorization_state="queued", scoring_state="unscored"
+    )
+
+    # No enum assignment — the blocked category arrives as a proposal.
+    fake_llm.queue(
+        "categorization",
+        BatchCategoryResponse(results=[cat_result(article.id, [], proposed="Crypto")]),
+    )
+
+    await CategorizationWorker().process_next_batch(test_session, batch_size=1)
+    # Run the scoring worker's poll: a blocked article must not be picked up.
+    await ScoringWorker().process_next_batch(test_session, batch_size=5)
+
+    test_session.expire_all()
+    updated = test_session.get(Article, article.id)
+    assert updated.scoring_state == "blocked"
+    assert updated.composite_score == 0.0
+    assert "Crypto" in (updated.score_reasoning or "")
+
+    # The scoring task was never invoked on the wrapper.
+    assert "scoring" not in fake_llm.tasks_invoked()
+
+
+# ---------------------------------------------------------------------------
+# Case 6: proposal creates a triage-flagged normal-weight category
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_proposal_creates_triage_category(
+    test_session, sample_feed, fake_llm, make_article, cat_result
+):
+    article = make_article(
+        sample_feed.id, categorization_state="queued", scoring_state="unscored"
+    )
+    fake_llm.queue(
+        "categorization",
+        BatchCategoryResponse(
+            results=[cat_result(article.id, [], proposed="Retro Computing")]
+        ),
+    )
+
+    await CategorizationWorker().process_next_batch(test_session, batch_size=1)
+
+    test_session.expire_all()
+    created = test_session.exec(
+        select(Category).where(Category.slug == "retro-computing")
+    ).first()
+    assert created is not None
+    assert created.weight == "normal"
+    assert created.needs_triage is True
+    assert created.parent_id is None
+
+    linked = _links_for(test_session, article.id)
+    assert [c.slug for c in linked] == ["retro-computing"]
+
+
+# ---------------------------------------------------------------------------
+# Case 7: alias -> survivor resolves to the target, no new row
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_alias_survivor_links_target_without_creating(
+    test_session, sample_feed, fake_llm, make_article, make_category, cat_result
+):
+    ai = make_category(display_name="AI", slug="ai", weight="normal")
+    test_session.add(CategoryAlias(alias_slug="crypto", target_id=ai.id))
+    test_session.commit()
+
+    article = make_article(
+        sample_feed.id, categorization_state="queued", scoring_state="unscored"
+    )
+    fake_llm.queue(
+        "categorization",
+        BatchCategoryResponse(results=[cat_result(article.id, [], proposed="Crypto")]),
+    )
+
+    await CategorizationWorker().process_next_batch(test_session, batch_size=1)
+
+    test_session.expire_all()
+    # No "crypto" category was created.
+    assert (
+        test_session.exec(select(Category).where(Category.slug == "crypto")).first()
+        is None
+    )
+    linked = _links_for(test_session, article.id)
+    assert [c.slug for c in linked] == ["ai"]
+
+
+# ---------------------------------------------------------------------------
+# Case 8: alias -> discard creates nothing; zero-category article still scores
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_alias_discard_creates_nothing_and_article_scores(
+    test_session, sample_feed, fake_llm, make_article, cat_result
+):
+    test_session.add(CategoryAlias(alias_slug="crypto", target_id=None))
+    test_session.commit()
+
+    article = make_article(
+        sample_feed.id, categorization_state="queued", scoring_state="unscored"
+    )
+    # No enum categories + a discarded proposal => zero assignments.
+    fake_llm.queue(
+        "categorization",
+        BatchCategoryResponse(results=[cat_result(article.id, [], proposed="Crypto")]),
+    )
+
+    await CategorizationWorker().process_next_batch(test_session, batch_size=1)
+
+    test_session.expire_all()
+    # Discard created no category.
+    assert (
+        test_session.exec(select(Category).where(Category.slug == "crypto")).first()
+        is None
+    )
+    assert _links_for(test_session, article.id) == []
+
+    # The article proceeds to scoring despite having no categories.
+    updated = test_session.get(Article, article.id)
+    assert updated.categorization_state == "categorized"
+    assert updated.scoring_state == "queued"
+
+
+# ---------------------------------------------------------------------------
+# Case 9: proposal matching an active category by slug links, no duplicate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_proposal_matches_active_by_slug(
+    test_session, sample_feed, fake_llm, make_article, make_category, cat_result
+):
+    make_category(
+        display_name="Artificial Intelligence", slug="artificial-intelligence"
+    )
+    article = make_article(
+        sample_feed.id, categorization_state="queued", scoring_state="unscored"
+    )
+    fake_llm.queue(
+        "categorization",
+        BatchCategoryResponse(
+            results=[cat_result(article.id, [], proposed="artificial-intelligence")]
+        ),
+    )
+
+    await CategorizationWorker().process_next_batch(test_session, batch_size=1)
+
+    test_session.expire_all()
+    matches = test_session.exec(
+        select(Category).where(Category.slug == "artificial-intelligence")
+    ).all()
+    assert len(matches) == 1  # no duplicate row
+
+    linked = _links_for(test_session, article.id)
+    assert [c.slug for c in linked] == ["artificial-intelligence"]
+
+
+# ---------------------------------------------------------------------------
+# Case 10: within-batch dedup of an identical proposal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_within_batch_proposal_dedup(
+    test_session, sample_feed, fake_llm, make_article, cat_result
+):
+    a1 = make_article(
+        sample_feed.id, categorization_state="queued", scoring_state="unscored"
+    )
+    a2 = make_article(
+        sample_feed.id, categorization_state="queued", scoring_state="unscored"
+    )
+    fake_llm.queue(
+        "categorization",
+        BatchCategoryResponse(
+            results=[
+                cat_result(a1.id, [], proposed="Quantum Computing"),
+                cat_result(a2.id, [], proposed="Quantum Computing"),
+            ]
+        ),
+    )
+
+    await CategorizationWorker().process_next_batch(test_session, batch_size=5)
+
+    test_session.expire_all()
+    rows = test_session.exec(
+        select(Category).where(Category.slug == "quantum-computing")
+    ).all()
+    assert len(rows) == 1  # exactly one row for both articles
+
+    for aid in (a1.id, a2.id):
+        assert [c.slug for c in _links_for(test_session, aid)] == ["quantum-computing"]
+
+
+# ---------------------------------------------------------------------------
+# Case 11: out-of-vocabulary enum name is dropped, never created
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_out_of_vocabulary_enum_name_is_dropped(
+    test_session, sample_feed, fake_llm, make_article, make_category
+):
+    make_category(display_name="AI", slug="ai", weight="normal")
+    article = make_article(
+        sample_feed.id, categorization_state="queued", scoring_state="unscored"
+    )
+
+    # model_construct bypasses the enum so we can simulate a strict-mode leak.
+    leaked = BatchCategoryResponse(
+        results=[
+            ArticleCategoryResult.model_construct(
+                article_id=article.id,
+                categories=["AI", "Nonexistent Topic"],
+                proposed_category=None,
+            )
+        ]
+    )
+    fake_llm.queue("categorization", leaked)
+
+    await CategorizationWorker().process_next_batch(test_session, batch_size=1)
+
+    test_session.expire_all()
+    # The unknown enum name created no category.
+    assert (
+        test_session.exec(
+            select(Category).where(Category.slug == "nonexistent-topic")
+        ).first()
+        is None
+    )
+    # The article is categorized with only the valid name.
+    updated = test_session.get(Article, article.id)
+    assert updated.categorization_state == "categorized"
+    assert [c.slug for c in _links_for(test_session, article.id)] == ["ai"]
+
+
+# ---------------------------------------------------------------------------
+# resolve_proposal unit coverage (the ladder in isolation)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveProposal:
+    def test_active_match_returns_without_creating(self, test_session, make_category):
+        make_category(display_name="AI", slug="ai")
+        before = len(test_session.exec(select(Category)).all())
+
+        resolved = resolve_proposal(test_session, "AI")
+
+        assert resolved is not None
+        assert resolved.slug == "ai"
+        assert len(test_session.exec(select(Category)).all()) == before
+
+    def test_alias_to_survivor_returns_target(self, test_session, make_category):
+        ai = make_category(display_name="AI", slug="ai")
+        test_session.add(CategoryAlias(alias_slug="crypto", target_id=ai.id))
+        test_session.commit()
+
+        resolved = resolve_proposal(test_session, "Crypto")
+
+        assert resolved is not None
+        assert resolved.slug == "ai"
+
+    def test_alias_discard_returns_none(self, test_session):
+        test_session.add(CategoryAlias(alias_slug="crypto", target_id=None))
+        test_session.commit()
+
+        assert resolve_proposal(test_session, "Crypto") is None
+
+    def test_unknown_name_creates_triage_category(self, test_session):
+        resolved = resolve_proposal(test_session, "Retro Computing")
+
+        assert resolved is not None
+        assert resolved.slug == "retro-computing"
+        assert resolved.weight == "normal"
+        assert resolved.needs_triage is True
+        assert resolved.parent_id is None

--- a/backend/tests/test_categorization_schema.py
+++ b/backend/tests/test_categorization_schema.py
@@ -1,0 +1,98 @@
+"""Unit tests for the per-batch categorization schema factory (ADR-0006).
+
+Pure — no DB, no client. The schema is built dynamically from the current
+vocabulary: `categories` is `list[Literal[*display_names]]` (a closed enum),
+falling back to `list[str]` when the vocabulary is empty. `proposed_category`
+is the single required-but-nullable proposal channel.
+"""
+
+import pydantic
+import pytest
+
+from backend.prompts.categorization import build_categorization_schema
+
+
+class TestClosedVocabularyEnforcement:
+    """Acceptance criterion 1: out-of-vocabulary assignment is unrepresentable."""
+
+    def test_in_vocabulary_category_validates(self):
+        schema = build_categorization_schema(["AI", "Programming"])
+        resp = schema.model_validate(
+            {
+                "results": [
+                    {"article_id": 1, "categories": ["AI"], "proposed_category": None}
+                ]
+            }
+        )
+        assert resp.results[0].categories == ["AI"]
+
+    def test_out_of_vocabulary_category_rejected(self):
+        schema = build_categorization_schema(["AI", "Programming"])
+        with pytest.raises(pydantic.ValidationError):
+            schema.model_validate(
+                {
+                    "results": [
+                        {
+                            "article_id": 1,
+                            "categories": ["Blockchain"],
+                            "proposed_category": None,
+                        }
+                    ]
+                }
+            )
+
+
+class TestEmptyVocabularyFallback:
+    """Empty vocabulary degrades to list[str] so the batch never deadlocks."""
+
+    def test_empty_vocabulary_accepts_arbitrary_strings(self):
+        schema = build_categorization_schema([])
+        resp = schema.model_validate(
+            {
+                "results": [
+                    {
+                        "article_id": 1,
+                        "categories": ["Anything", "Goes"],
+                        "proposed_category": None,
+                    }
+                ]
+            }
+        )
+        assert resp.results[0].categories == ["Anything", "Goes"]
+
+
+class TestProposalChannel:
+    """proposed_category is a single required-but-nullable string field."""
+
+    def test_proposed_category_accepts_string(self):
+        schema = build_categorization_schema(["AI"])
+        resp = schema.model_validate(
+            {
+                "results": [
+                    {
+                        "article_id": 1,
+                        "categories": [],
+                        "proposed_category": "Retro Computing",
+                    }
+                ]
+            }
+        )
+        assert resp.results[0].proposed_category == "Retro Computing"
+
+    def test_proposed_category_accepts_none(self):
+        schema = build_categorization_schema(["AI"])
+        resp = schema.model_validate(
+            {
+                "results": [
+                    {"article_id": 1, "categories": [], "proposed_category": None}
+                ]
+            }
+        )
+        assert resp.results[0].proposed_category is None
+
+    def test_proposed_category_is_required(self):
+        # Required-but-nullable: the key must be present (framing proposal as
+        # the deliberate exception path, per ADR-0006).
+        schema = build_categorization_schema(["AI"])
+        with pytest.raises(pydantic.ValidationError):
+            schema.model_validate({"results": [{"article_id": 1, "categories": []}]})

--- a/backend/tests/test_scoring_lifecycle.py
+++ b/backend/tests/test_scoring_lifecycle.py
@@ -157,8 +157,7 @@ async def test_blocked_articles_appear_only_in_blocked_view(
                 ArticleCategoryResult(
                     article_id=article.id,
                     categories=["Crypto"],
-                    suggested_new=[],
-                    suggested_parent=None,
+                    proposed_category=None,
                 )
             ]
         ),

--- a/backend/tests/test_scoring_queue_batch.py
+++ b/backend/tests/test_scoring_queue_batch.py
@@ -13,7 +13,6 @@ from sqlmodel import select
 from backend.llm_client import LLMCallFailed, LLMNotConfigured, LLMUnavailable
 from backend.models import Article, ArticleCategoryLink, Category, Feed
 from backend.prompts import (
-    ArticleCategoryResult,
     ArticleScoringResult,
     BatchCategoryResponse,
     BatchScoringResponse,
@@ -45,15 +44,6 @@ def _make_queued_article(
     session.commit()
     session.refresh(article)
     return article
-
-
-def _cat_result(article_id: int, categories: list[str], **kw) -> ArticleCategoryResult:
-    return ArticleCategoryResult(
-        article_id=article_id,
-        categories=categories,
-        suggested_new=kw.get("suggested_new", []),
-        suggested_parent=kw.get("suggested_parent"),
-    )
 
 
 def _score_result(article_id: int, interest=7, quality=8) -> ArticleScoringResult:
@@ -97,14 +87,14 @@ async def test_categorization_happy_path(test_session, sample_feed, fake_llm):
 
 @pytest.mark.asyncio
 async def test_categorization_blocked_category_blocks_article(
-    test_session, sample_feed, fake_llm, make_category
+    test_session, sample_feed, fake_llm, make_category, cat_result
 ):
     make_category(display_name="Crypto", slug="crypto", weight="block")
     article = _make_queued_article(test_session, sample_feed, 1)
 
     fake_llm.queue(
         "categorization",
-        BatchCategoryResponse(results=[_cat_result(article.id, ["Crypto"])]),
+        BatchCategoryResponse(results=[cat_result(article.id, ["Crypto"])]),
     )
 
     worker = CategorizationWorker()
@@ -120,14 +110,14 @@ async def test_categorization_blocked_category_blocks_article(
 
 @pytest.mark.asyncio
 async def test_categorization_drops_hallucinated_and_requeues_missing(
-    test_session, sample_feed, fake_llm
+    test_session, sample_feed, fake_llm, cat_result
 ):
     article = _make_queued_article(test_session, sample_feed, 1)
 
     # Response references an id that was never sent; the sent id is missing
     fake_llm.queue(
         "categorization",
-        BatchCategoryResponse(results=[_cat_result(999999, ["Technology"])]),
+        BatchCategoryResponse(results=[cat_result(999999, ["Technology"])]),
     )
 
     worker = CategorizationWorker()

--- a/docs/adr/0006-categorization-response-contract.md
+++ b/docs/adr/0006-categorization-response-contract.md
@@ -1,0 +1,16 @@
+# The categorization response contract is a per-batch schema: display-name enums plus one nullable proposal field
+
+The categorization response schema is built dynamically per batch by a schema factory. Assignment is `categories: list[Literal[...]]` where the enum members are the display names of every category in the vocabulary — strict structured outputs make out-of-vocabulary assignment impossible at generation time, which is the enforcement mechanism ADR-0001 requires. The proposal channel is a single `proposed_category: str | None` field; `null` is the structural default, framing proposal as the exception path.
+
+## Why
+
+- **Display names over slugs or IDs**: the model semantically matches article content against human-readable strings; strict mode guarantees the emitted string is verbatim from the enum, so the slug lookup on our side can never miss. IDs would force the model to cross-reference a legend — the same hallucination-shaped indirection the closed vocabulary removes.
+- **One proposal, not a list**: vocabulary growth should be deliberate (one new category per article per pass). An article about two novel topics self-heals — the second topic recurs and gets proposed later. The scalar shape structurally reinforces the "only when nothing fits" rule.
+- **Prompt-enforced limits**: strict mode rejects constraint keywords like `maxItems`, so the 1–4 categories-per-article limit stays in the prompt with worker-side clamping. Schemas stay free of constraint keywords.
+
+## Consequences
+
+- **Empty vocabulary degrades, never deadlocks**: `Literal` with zero members is untypable, so when the vocabulary is empty the factory falls back to `categories: list[str]` for that batch. The worker's name→category mapping drops and logs any lookup miss unconditionally — creation flows only through the proposal ladder (active match → alias → create-or-discard), so the fallback can mislabel nothing and create nothing. Proposals bootstrap the vocabulary back within a few batches. Parking the queue instead was rejected as a silent deadlock.
+- Drop-on-miss doubles as defense-in-depth if strict mode ever leaks an out-of-enum string: worst case is a dropped label, never a created category.
+- Groups are never serialized into the categorization prompt and the response carries no parent suggestion (ADR-0001) — new categories are born ungrouped; shelving belongs to auto-grouping and triage.
+- The schema changes with the vocabulary, so canned test responses must be validated through the schema the worker hands the mocked wrapper — which makes every worker test also a test of the enum.


### PR DESCRIPTION
# Closed category vocabulary + single proposal channel

## What is this PR about?

Categorization now enforces the closed vocabulary at the schema level: the LLM can only assign existing categories, and new ones enter solely through an explicit proposal field that resolves aliases before creating anything.

## Why is this change needed?

v1 let any unrecognized string in the LLM response silently become a category row, so the vocabulary drifted out of control (duplicates, junk, un-hidden categories). ADR-0001 closes the vocabulary; issue #90 implements it.

## How is this change implemented?

- A per-batch schema factory constrains `categories` to a `Literal` enum of active display names (empty vocabulary degrades to `list[str]` with drop-and-log, never deadlock) — ADR-0006
- One nullable `proposed_category` field per article, resolved through the alias ladder: active match → alias survivor → alias discard → create at weight normal, flagged for triage
- v1 silent-creation paths deleted (`get_or_create_category`, `suggested_new`/`suggested_parent`, hierarchy serialized into the prompt)
- Blocked short-circuit unchanged (score 0, scoring LLM skipped) and now covered by tests, including the proposal-only route
- Test fake reworked to validate canned responses through the real per-batch schema; 21 new tests (191 total)

## How to test this change?

1. From `backend/`, run `uv run pytest` — 191 tests should pass.
2. Start the backend with Azure credentials configured and add a feed; watch articles get categorized only into existing categories.
3. Check the categories list for any LLM-proposed category: it should be usable immediately and flagged as new.
4. Set a category's weight to block and rescore: articles with that category land in the blocked view with score 0.

## Notes

- Alias *creation* (merge/rename verbs) is #91; this PR only resolves existing aliases.
- Closes #26 rationale: parent suggestions are structurally excluded (groups never serialized into prompts, ADR-0001).
- Pyright has 5 pre-existing errors in untouched files (`feeds.py`, `routers/articles.py`, `routers/feeds.py`) — not from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
