### PR TITLE
v2: category management rework — triage verbs, aliases, groups (#91)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,7 +17,7 @@ The absolute weight: an article carrying any blocked category scores zero, skips
 _Avoid_: hidden, banned, excluded
 
 **Alias**:
-A remembered former category name that deterministically resolves future LLM proposals to a surviving category (or to discard). Created when categories are merged or renamed; prevents deleted junk from being recreated.
+A remembered former category name that deterministically resolves future LLM proposals to a surviving category (or to discard). Created when categories are merged or renamed, and as a discard when a category is deleted; prevents deleted junk from being recreated. Explicitly creating a category with an aliased name overrides the memory.
 _Avoid_: synonym list, tombstone
 
 **Proposal**:
@@ -25,7 +25,7 @@ The single channel by which the categorization LLM nominates a category name whe
 _Avoid_: suggestion, suggested category
 
 **Category triage**:
-Reviewing LLM-created categories after the fact — keep, rename, merge, or suppress. New categories are live and usable from the moment of creation; triage is cleanup, never a approval gate.
+Reviewing LLM-created categories after the fact — keep, rename, merge, or block. New categories are live and usable from the moment of creation; triage is cleanup, never an approval gate.
 _Avoid_: category approval, moderation queue
 
 **Reader**:

--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -48,10 +48,11 @@ class WeightMultipliers(BaseModel):
     """Configurable category weight multipliers.
 
     'normal' (1.0, definitional identity) and 'block' (short-circuited
-    before scoring) are pinned in code, not configurable.
+    before scoring) are pinned in code, not configurable — unknown keys
+    (e.g. normal/block) fail at startup.
     """
 
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="forbid")
 
     reduce: float = 0.5
     boost: float = 1.5

--- a/backend/src/backend/config.py
+++ b/backend/src/backend/config.py
@@ -44,6 +44,28 @@ class SchedulerConfig(BaseModel):
     log_job_execution: bool = False
 
 
+class WeightMultipliers(BaseModel):
+    """Configurable category weight multipliers.
+
+    'normal' (1.0, definitional identity) and 'block' (short-circuited
+    before scoring) are pinned in code, not configurable.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    reduce: float = 0.5
+    boost: float = 1.5
+    max: float = 2.0
+
+
+class ScoringConfig(BaseModel):
+    """Scoring configuration."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    weight_multipliers: WeightMultipliers = WeightMultipliers()
+
+
 class LLMTaskConfig(BaseModel):
     """Per-task Azure deployment routing."""
 
@@ -86,6 +108,7 @@ class Settings(BaseSettings):
     database: DatabaseConfig = DatabaseConfig()
     logging: LoggingConfig = LoggingConfig()
     scheduler: SchedulerConfig = SchedulerConfig()
+    scoring: ScoringConfig = ScoringConfig()
     llm: LLMConfig = LLMConfig()
 
     # Azure credentials — env only (AZURE_OPENAI_ENDPOINT / AZURE_OPENAI_API_KEY),

--- a/backend/src/backend/feeds.py
+++ b/backend/src/backend/feeds.py
@@ -142,6 +142,7 @@ async def refresh_feed(session: Session, feed: Feed) -> int:
         session.commit()
 
         # Save articles and enqueue for scoring
+        assert feed.id is not None
         new_count, new_article_ids = save_articles(
             session,
             feed.id,

--- a/backend/src/backend/models.py
+++ b/backend/src/backend/models.py
@@ -1,10 +1,25 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import Optional
 
 from sqlalchemy import CheckConstraint
 from sqlmodel import Field, Relationship, SQLModel
 
-CATEGORY_WEIGHTS = ("block", "reduce", "normal", "boost", "max")
+
+class CategoryWeight(StrEnum):
+    """The category weight vocabulary — single source of truth.
+
+    The DB CHECK constraint, request validation, and the scoring
+    multiplier table all derive from these members.
+    """
+
+    BLOCK = "block"
+    REDUCE = "reduce"
+    NORMAL = "normal"
+    BOOST = "boost"
+    MAX = "max"
+
+
 FEEDBACK_EVENT_TYPES = ("opened", "marked_read", "rated", "rescued")
 CATEGORIZATION_STATES = (
     "uncategorized",
@@ -79,7 +94,8 @@ class Category(SQLModel, table=True):
     __tablename__ = "categories"  # pyright: ignore[reportAssignmentType]
     __table_args__ = (
         CheckConstraint(
-            _in_clause("weight", CATEGORY_WEIGHTS), name="ck_categories_weight"
+            _in_clause("weight", tuple(w.value for w in CategoryWeight)),
+            name="ck_categories_weight",
         ),
     )
 

--- a/backend/src/backend/routers/articles.py
+++ b/backend/src/backend/routers/articles.py
@@ -145,7 +145,7 @@ def list_articles(
 
     if scoring_state == "pending":
         statement = statement.where(
-            Article.composite_score.is_(None),  # pyright: ignore[reportAttributeAccessIssue]  # first-time only — excludes re-evaluating
+            Article.composite_score.is_(None),  # pyright: ignore[reportAttributeAccessIssue, reportOptionalMemberAccess]  # first-time only — excludes re-evaluating
             (
                 Article.scoring_state.in_(["unscored", "queued", "scoring"])  # pyright: ignore[reportAttributeAccessIssue]
                 | Article.categorization_state.in_(["queued", "categorizing"])  # pyright: ignore[reportAttributeAccessIssue]
@@ -173,12 +173,12 @@ def list_articles(
     if sort_by == "composite_score":
         if order == "desc":
             statement = statement.order_by(
-                nulls_last(desc(Article.composite_score)),
+                nulls_last(desc(Article.composite_score)),  # pyright: ignore[reportArgumentType]
                 Article.published_at.asc(),  # pyright: ignore[reportArgumentType, reportAttributeAccessIssue, reportOptionalMemberAccess]
             )
         else:
             statement = statement.order_by(
-                nulls_last(Article.composite_score),
+                nulls_last(Article.composite_score),  # pyright: ignore[reportArgumentType]
                 Article.published_at.asc(),  # pyright: ignore[reportArgumentType, reportAttributeAccessIssue, reportOptionalMemberAccess]
             )
     elif sort_by == "published_at":

--- a/backend/src/backend/routers/categories.py
+++ b/backend/src/backend/routers/categories.py
@@ -23,8 +23,6 @@ from backend.schemas import (
     GroupSuggestionItem,
 )
 
-VALID_WEIGHTS = {"block", "reduce", "normal", "boost", "max"}
-
 router = APIRouter(prefix="/api/categories", tags=["categories"])
 
 
@@ -440,12 +438,7 @@ def update_category(
         category.parent_id = None
 
     if body.weight is not None:
-        if body.weight not in VALID_WEIGHTS:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Invalid weight '{body.weight}'. Must be one of: {', '.join(sorted(VALID_WEIGHTS))}",
-            )
-        category.weight = body.weight
+        category.weight = body.weight.value
 
     if body.needs_triage is not None:
         category.needs_triage = body.needs_triage

--- a/backend/src/backend/routers/categories.py
+++ b/backend/src/backend/routers/categories.py
@@ -131,6 +131,11 @@ def create_category(
         parent = session.get(Category, body.parent_id)
         if not parent:
             raise HTTPException(status_code=404, detail="Parent category not found")
+        if parent.parent_id is not None:
+            raise HTTPException(
+                status_code=400,
+                detail="Target must be a root category (no parent)",
+            )
 
     # Explicit creation overrides remembered discard/redirect (ADR-0007)
     _delete_alias(session, slug)
@@ -159,19 +164,18 @@ def bulk_update_categories(
     batch-block = {weight: "block", needs_triage: false}. Missing ids are
     skipped and reported, never a failure.
     """
-    updated = 0
-    missing_ids: list[int] = []
-    for cat_id in body.category_ids:
-        category = session.get(Category, cat_id)
-        if not category:
-            missing_ids.append(cat_id)
-            continue
+    categories = session.exec(
+        select(Category).where(Category.id.in_(body.category_ids))  # pyright: ignore[reportOptionalMemberAccess, reportAttributeAccessIssue]
+    ).all()
+    missing_ids = sorted(set(body.category_ids) - {c.id for c in categories})
+
+    for category in categories:
         if body.weight is not None:
             category.weight = body.weight.value
         if body.needs_triage is not None:
             category.needs_triage = body.needs_triage
         session.add(category)
-        updated += 1
+    updated = len(categories)
 
     session.commit()
     return CategoryBulkUpdateResponse(ok=True, updated=updated, missing_ids=missing_ids)
@@ -272,7 +276,7 @@ def merge_categories(
                 category_id=body.target_id,
             )
             session.add(new_link)
-        articles_moved += 1
+            articles_moved += 1
 
     # Release children to root — groups are display-only shelves (ADR-0001);
     # the merge survivor's shelf is not the children's shelf.
@@ -431,20 +435,28 @@ def auto_group_apply(
     all_categories = session.exec(select(Category)).all()
     slug_map: dict[str, Category] = {c.slug: c for c in all_categories}
 
-    # Step 3: Apply new groups (first assignment wins for duplicate children)
+    # Step 3: Apply new groups (first assignment wins for duplicate children,
+    # and for parent-vs-child conflicts — the hierarchy stays one level deep)
     groups_applied = 0
     categories_moved = 0
     assigned_slugs: set[str] = set()
+    parent_slugs: set[str] = set()
     for group in body.groups:
         parent_slug = slugify(group.parent)
         parent_cat = slug_map.get(parent_slug)
         if not parent_cat:
+            continue
+        # A slug already assigned as a child cannot also be a parent
+        if parent_slug in assigned_slugs:
             continue
 
         moved_in_group = 0
         for child_name in group.children:
             child_slug = slugify(child_name)
             if child_slug in assigned_slugs:
+                continue
+            # A slug already used as a parent keeps its children
+            if child_slug in parent_slugs:
                 continue
             child_cat = slug_map.get(child_slug)
             if not child_cat:
@@ -460,6 +472,7 @@ def auto_group_apply(
         if moved_in_group > 0:
             groups_applied += 1
             categories_moved += moved_in_group
+            parent_slugs.add(parent_slug)
 
     session.commit()
     return AutoGroupApplyResponse(

--- a/backend/src/backend/routers/categories.py
+++ b/backend/src/backend/routers/categories.py
@@ -14,8 +14,11 @@ from backend.schemas import (
     AutoGroupApplyResponse,
     AutoGroupSuggestResponse,
     CategoryAcknowledgeRequest,
+    CategoryAliasResponse,
     CategoryBatchAction,
     CategoryBatchMove,
+    CategoryBulkUpdate,
+    CategoryBulkUpdateResponse,
     CategoryCreateRequest,
     CategoryMerge,
     CategoryMergeResponse,
@@ -73,9 +76,13 @@ def _category_to_response(session: Session, category: Category) -> CategoryRespo
 
 @router.get("", response_model=list[CategoryResponse])
 def list_categories(
+    needs_triage: bool | None = None,
     session: Session = Depends(get_session),
 ):
-    """Get flat list of all categories with article counts."""
+    """Get flat list of all categories with article counts.
+
+    Optionally filter by triage state (needs_triage=true → the triage list).
+    """
     statement = (
         select(
             Category,
@@ -85,6 +92,8 @@ def list_categories(
         .group_by(Category.id)  # pyright: ignore[reportArgumentType]
         .order_by(Category.display_name)
     )
+    if needs_triage is not None:
+        statement = statement.where(Category.needs_triage == needs_triage)  # pyright: ignore[reportArgumentType]
     results = session.exec(statement).all()
 
     return [
@@ -137,6 +146,60 @@ def create_category(
     session.refresh(category)
 
     return _category_to_response(session, category)
+
+
+@router.patch("", response_model=CategoryBulkUpdateResponse)
+def bulk_update_categories(
+    body: CategoryBulkUpdate,
+    session: Session = Depends(get_session),
+):
+    """Apply weight and/or triage state to many categories in one transaction.
+
+    Triage gestures compose from this: keep = {needs_triage: false},
+    batch-block = {weight: "block", needs_triage: false}. Missing ids are
+    skipped and reported, never a failure.
+    """
+    updated = 0
+    missing_ids: list[int] = []
+    for cat_id in body.category_ids:
+        category = session.get(Category, cat_id)
+        if not category:
+            missing_ids.append(cat_id)
+            continue
+        if body.weight is not None:
+            category.weight = body.weight.value
+        if body.needs_triage is not None:
+            category.needs_triage = body.needs_triage
+        session.add(category)
+        updated += 1
+
+    session.commit()
+    return CategoryBulkUpdateResponse(ok=True, updated=updated, missing_ids=missing_ids)
+
+
+# Literal path — declared before the /{category_id} routes so it can never
+# be shadowed by the path-param match.
+@router.get("/aliases", response_model=list[CategoryAliasResponse])
+def list_aliases(
+    session: Session = Depends(get_session),
+):
+    """List all alias rows (ADR-0007). NULL target = remembered discard."""
+    aliases = session.exec(
+        select(CategoryAlias).order_by(CategoryAlias.alias_slug)
+    ).all()
+    names_by_id = {c.id: c.display_name for c in session.exec(select(Category)).all()}
+    return [
+        CategoryAliasResponse(
+            id=alias.id,  # pyright: ignore[reportArgumentType]
+            alias_slug=alias.alias_slug,
+            target_id=alias.target_id,
+            target_display_name=names_by_id.get(alias.target_id)
+            if alias.target_id is not None
+            else None,
+            created_at=alias.created_at,
+        )
+        for alias in aliases
+    ]
 
 
 @router.get("/unseen-count")

--- a/backend/src/backend/routers/categories.py
+++ b/backend/src/backend/routers/categories.py
@@ -7,7 +7,7 @@ from sqlmodel import Session, func, select
 from backend.database import smart_case
 from backend.deps import TASK_GROUPING, get_session
 from backend.llm_client import LLMError, llm_client
-from backend.models import ArticleCategoryLink, Category
+from backend.models import ArticleCategoryLink, Category, CategoryAlias
 from backend.prompts import GroupingResponse, build_grouping_prompt
 from backend.schemas import (
     AutoGroupApplyRequest,
@@ -18,12 +18,35 @@ from backend.schemas import (
     CategoryBatchMove,
     CategoryCreateRequest,
     CategoryMerge,
+    CategoryMergeResponse,
     CategoryResponse,
     CategoryUpdate,
     GroupSuggestionItem,
+    MergeChildReleased,
 )
 
 router = APIRouter(prefix="/api/categories", tags=["categories"])
+
+
+def _upsert_alias(session: Session, alias_slug: str, target_id: int | None) -> None:
+    """Create or repoint an alias (ADR-0007) without violating the slug UNIQUE."""
+    alias = session.exec(
+        select(CategoryAlias).where(CategoryAlias.alias_slug == alias_slug)
+    ).first()
+    if alias:
+        alias.target_id = target_id
+        session.add(alias)
+    else:
+        session.add(CategoryAlias(alias_slug=alias_slug, target_id=target_id))
+
+
+def _delete_alias(session: Session, alias_slug: str) -> None:
+    """Erase alias memory for a slug — explicit human act overrides it (ADR-0007)."""
+    alias = session.exec(
+        select(CategoryAlias).where(CategoryAlias.alias_slug == alias_slug)
+    ).first()
+    if alias:
+        session.delete(alias)
 
 
 def _category_article_count(session: Session, category_id: int) -> int:
@@ -100,6 +123,9 @@ def create_category(
         if not parent:
             raise HTTPException(status_code=404, detail="Parent category not found")
 
+    # Explicit creation overrides remembered discard/redirect (ADR-0007)
+    _delete_alias(session, slug)
+
     # User-created categories never need triage
     category = Category(
         display_name=smart_case(body.display_name),
@@ -144,12 +170,12 @@ def mark_seen(
     return {"ok": True}
 
 
-@router.post("/merge")
+@router.post("/merge", response_model=CategoryMergeResponse)
 def merge_categories(
     body: CategoryMerge,
     session: Session = Depends(get_session),
 ):
-    """Merge source category into target. Moves article associations, reparents children, deletes source."""
+    """Merge source into target: move articles, release children to root, alias the source name."""
     if body.source_id == body.target_id:
         raise HTTPException(
             status_code=400, detail="Source and target must be different"
@@ -185,17 +211,39 @@ def merge_categories(
             session.add(new_link)
         articles_moved += 1
 
+    # Release children to root — groups are display-only shelves (ADR-0001);
+    # the merge survivor's shelf is not the children's shelf.
     source_children = session.exec(
         select(Category).where(Category.parent_id == body.source_id)
     ).all()
+    children_released = [
+        MergeChildReleased(id=child.id, display_name=child.display_name)  # pyright: ignore[reportArgumentType]
+        for child in source_children
+    ]
     for child in source_children:
-        child.parent_id = body.target_id
+        child.parent_id = None
         session.add(child)
+
+    # Repoint the source's aliases explicitly — relying on ON DELETE SET NULL
+    # would silently turn redirects into discards (ADR-0007).
+    source_aliases = session.exec(
+        select(CategoryAlias).where(CategoryAlias.target_id == body.source_id)
+    ).all()
+    for alias in source_aliases:
+        alias.target_id = body.target_id
+        session.add(alias)
+
+    _upsert_alias(session, source.slug, body.target_id)
 
     session.delete(source)
     session.commit()
 
-    return {"ok": True, "articles_moved": articles_moved}
+    return CategoryMergeResponse(
+        ok=True,
+        articles_moved=articles_moved,
+        children_released=children_released,
+        aliases_repointed=len(source_aliases),
+    )
 
 
 @router.post("/batch-move")
@@ -383,6 +431,8 @@ def batch_delete_categories(
             )
         )
         session.delete(category)
+        # Discard alias: removed junk stays dead (ADR-0007)
+        _upsert_alias(session, category.slug, None)
         deleted += 1
 
     session.commit()
@@ -412,10 +462,16 @@ def update_category(
         if existing:
             raise HTTPException(
                 status_code=409,
-                detail=f"Category '{body.display_name}' already exists",
+                detail=f"Category '{body.display_name}' already exists — use merge instead",
             )
+        old_slug = category.slug
         category.display_name = smart_case(body.display_name)
         category.slug = new_slug
+        if new_slug != old_slug:
+            # The new name is live again — erase remembered alias; leave one
+            # for the vacated name (ADR-0007).
+            _delete_alias(session, new_slug)
+            _upsert_alias(session, old_slug, category_id)
 
     if body.parent_id is not None:
         if body.parent_id == -1:
@@ -433,6 +489,19 @@ def update_category(
             parent = session.get(Category, body.parent_id)
             if not parent:
                 raise HTTPException(status_code=404, detail="Parent category not found")
+            if parent.parent_id is not None:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Target must be a root category (no parent)",
+                )
+            children = session.exec(
+                select(Category).where(Category.parent_id == category_id)
+            ).all()
+            if children:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Category '{category.display_name}' has children and cannot be nested under another parent",
+                )
             category.parent_id = body.parent_id
     elif body.model_fields_set and "parent_id" in body.model_fields_set:
         category.parent_id = None
@@ -476,6 +545,8 @@ def delete_category(
     )
 
     session.delete(category)
+    # Discard alias: removed junk stays dead (ADR-0007)
+    _upsert_alias(session, category.slug, None)
     session.commit()
 
     return {"ok": True}

--- a/backend/src/backend/routers/feeds.py
+++ b/backend/src/backend/routers/feeds.py
@@ -122,6 +122,7 @@ async def create_feed(
     session.commit()
     session.refresh(feed)
 
+    assert feed.id is not None
     article_count, new_article_ids = save_articles(
         session,
         feed.id,

--- a/backend/src/backend/schemas.py
+++ b/backend/src/backend/schemas.py
@@ -4,6 +4,8 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
+from backend.models import CategoryWeight
+
 # --- General ---
 
 
@@ -170,7 +172,7 @@ class CategoryCreateRequest(BaseModel):
 class CategoryUpdate(BaseModel):
     display_name: str | None = None
     parent_id: int | None = None
-    weight: str | None = None
+    weight: CategoryWeight | None = None
     needs_triage: bool | None = None
 
 

--- a/backend/src/backend/schemas.py
+++ b/backend/src/backend/schemas.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from backend.models import CategoryWeight
 
@@ -174,6 +174,36 @@ class CategoryUpdate(BaseModel):
     parent_id: int | None = None
     weight: CategoryWeight | None = None
     needs_triage: bool | None = None
+
+
+class CategoryBulkUpdate(BaseModel):
+    """Collection PATCH body — triage gestures compose from these fields."""
+
+    category_ids: list[int]
+    weight: CategoryWeight | None = None
+    needs_triage: bool | None = None
+
+    @model_validator(mode="after")
+    def require_at_least_one_field(self):
+        if self.weight is None and self.needs_triage is None:
+            raise ValueError("Provide at least one of weight or needs_triage")
+        return self
+
+
+class CategoryBulkUpdateResponse(BaseModel):
+    ok: bool
+    updated: int
+    missing_ids: list[int]
+
+
+class CategoryAliasResponse(BaseModel):
+    """Alias row for the read-only listing; target_display_name is None for discards."""
+
+    id: int
+    alias_slug: str
+    target_id: int | None
+    target_display_name: str | None
+    created_at: datetime
 
 
 class CategoryMerge(BaseModel):

--- a/backend/src/backend/schemas.py
+++ b/backend/src/backend/schemas.py
@@ -181,6 +181,18 @@ class CategoryMerge(BaseModel):
     target_id: int
 
 
+class MergeChildReleased(BaseModel):
+    id: int
+    display_name: str
+
+
+class CategoryMergeResponse(BaseModel):
+    ok: bool
+    articles_moved: int
+    children_released: list[MergeChildReleased]
+    aliases_repointed: int
+
+
 class CategoryAcknowledgeRequest(BaseModel):
     category_ids: list[int]
 

--- a/backend/src/backend/scoring.py
+++ b/backend/src/backend/scoring.py
@@ -6,20 +6,30 @@ from collections.abc import Sequence
 from slugify import slugify
 from sqlmodel import Session, select
 
+from backend.config import get_settings
 from backend.database import smart_case
-from backend.models import Category, CategoryAlias
+from backend.models import Category, CategoryAlias, CategoryWeight
 
 logger = logging.getLogger(__name__)
 
 MAX_COMPOSITE_SCORE = 20.0
 
-WEIGHT_MULTIPLIERS = {
-    "block": 0.0,
-    "reduce": 0.5,
-    "normal": 1.0,
-    "boost": 1.5,
-    "max": 2.0,
-}
+
+def _weight_multipliers() -> dict[str, float]:
+    """Weight -> multiplier map from config, plus two pinned entries.
+
+    'normal' is 1.0 by definition and 'block' is short-circuited via
+    is_blocked() before scoring — its 0.0 here is defense-in-depth in
+    case a blocked category ever reaches the math. Neither is configurable.
+    """
+    configured = get_settings().scoring.weight_multipliers
+    return {
+        CategoryWeight.BLOCK: 0.0,
+        CategoryWeight.REDUCE: configured.reduce,
+        CategoryWeight.NORMAL: 1.0,
+        CategoryWeight.BOOST: configured.boost,
+        CategoryWeight.MAX: configured.max,
+    }
 
 
 def resolve_proposal(session: Session, proposed_name: str) -> Category | None:
@@ -58,7 +68,7 @@ def resolve_proposal(session: Session, proposed_name: str) -> Category | None:
     category = Category(
         display_name=smart_case(proposed_name),
         slug=slug,
-        weight="normal",
+        weight=CategoryWeight.NORMAL,
         needs_triage=True,
     )
     session.add(category)
@@ -73,8 +83,10 @@ def compute_composite_score(
     """Compute final composite score from interest, quality, and category weights.
 
     Formula: interest_score * category_multiplier * quality_multiplier
-    Capped at 20.0 maximum. Weights apply directly — groups are display-only
-    shelves and never affect scoring (ADR-0001).
+    Capped at 20.0 maximum. Weight multipliers come from config
+    (scoring.weight_multipliers; normal/block are pinned in code).
+    Weights apply directly — groups are display-only shelves and never
+    affect scoring (ADR-0001).
 
     Args:
         interest_score: Interest score 0-10
@@ -87,9 +99,8 @@ def compute_composite_score(
     if not categories:
         category_multiplier = 1.0
     else:
-        weights = [
-            WEIGHT_MULTIPLIERS.get(category.weight, 1.0) for category in categories
-        ]
+        multipliers = _weight_multipliers()
+        weights = [multipliers.get(category.weight, 1.0) for category in categories]
         category_multiplier = sum(weights) / len(weights)
 
     # Quality multiplier: maps 0-10 to 0.5-1.0
@@ -102,7 +113,7 @@ def compute_composite_score(
 
 def is_blocked(categories: list[Category]) -> bool:
     """True if any category carries the blocked weight."""
-    return any(category.weight == "block" for category in categories)
+    return any(category.weight == CategoryWeight.BLOCK for category in categories)
 
 
 def load_categories(session: Session) -> Sequence[Category]:

--- a/backend/src/backend/scoring.py
+++ b/backend/src/backend/scoring.py
@@ -15,23 +15,6 @@ logger = logging.getLogger(__name__)
 MAX_COMPOSITE_SCORE = 20.0
 
 
-def _weight_multipliers() -> dict[str, float]:
-    """Weight -> multiplier map from config, plus two pinned entries.
-
-    'normal' is 1.0 by definition and 'block' is short-circuited via
-    is_blocked() before scoring — its 0.0 here is defense-in-depth in
-    case a blocked category ever reaches the math. Neither is configurable.
-    """
-    configured = get_settings().scoring.weight_multipliers
-    return {
-        CategoryWeight.BLOCK: 0.0,
-        CategoryWeight.REDUCE: configured.reduce,
-        CategoryWeight.NORMAL: 1.0,
-        CategoryWeight.BOOST: configured.boost,
-        CategoryWeight.MAX: configured.max,
-    }
-
-
 def resolve_proposal(session: Session, proposed_name: str) -> Category | None:
     """Resolve a proposed category name through the proposal ladder (ADR-0001).
 
@@ -99,7 +82,19 @@ def compute_composite_score(
     if not categories:
         category_multiplier = 1.0
     else:
-        multipliers = _weight_multipliers()
+        # Weight -> multiplier map from config, plus two pinned entries:
+        # 'normal' is 1.0 by definition and 'block' is short-circuited via
+        # is_blocked() before scoring — its 0.0 here is defense-in-depth in
+        # case a blocked category ever reaches the math. Neither is
+        # configurable.
+        configured = get_settings().scoring.weight_multipliers
+        multipliers: dict[str, float] = {
+            CategoryWeight.BLOCK: 0.0,
+            CategoryWeight.REDUCE: configured.reduce,
+            CategoryWeight.NORMAL: 1.0,
+            CategoryWeight.BOOST: configured.boost,
+            CategoryWeight.MAX: configured.max,
+        }
         weights = [multipliers.get(category.weight, 1.0) for category in categories]
         category_multiplier = sum(weights) / len(weights)
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -221,3 +221,27 @@ def test_create_feed_includes_folder_fields_in_response(
     assert data["title"] == "Patched Feed"
     assert data["folder_id"] is None
     assert data["folder_name"] is None
+
+
+# --- Category weight updates ---
+
+
+def test_update_category_weight_valid(test_client: TestClient, make_category):
+    """PATCH with a valid weight persists it."""
+    category = make_category()
+    response = test_client.patch(
+        f"/api/categories/{category.id}", json={"weight": "boost"}
+    )
+    assert response.status_code == 200
+    assert response.json()["weight"] == "boost"
+
+
+def test_update_category_weight_invalid_returns_422(
+    test_client: TestClient, make_category
+):
+    """PATCH with an unknown weight fails schema validation (422, not 400)."""
+    category = make_category()
+    response = test_client.patch(
+        f"/api/categories/{category.id}", json={"weight": "mega"}
+    )
+    assert response.status_code == 422

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -234,14 +234,3 @@ def test_update_category_weight_valid(test_client: TestClient, make_category):
     )
     assert response.status_code == 200
     assert response.json()["weight"] == "boost"
-
-
-def test_update_category_weight_invalid_returns_422(
-    test_client: TestClient, make_category
-):
-    """PATCH with an unknown weight fails schema validation (422, not 400)."""
-    category = make_category()
-    response = test_client.patch(
-        f"/api/categories/{category.id}", json={"weight": "mega"}
-    )
-    assert response.status_code == 422

--- a/backend/tests/test_auto_group.py
+++ b/backend/tests/test_auto_group.py
@@ -183,6 +183,73 @@ class TestAutoGroupApply:
         assert shared.parent_id == group_a.id  # First assignment wins
         assert other.parent_id == group_a.id
 
+    def test_never_creates_depth_two_trees(
+        self,
+        test_client: TestClient,
+        test_session: Session,
+        make_category: Callable[..., Category],
+    ):
+        """Chained groups (A > B, then B > C) must not nest C under a child.
+
+        A group whose parent was already assigned as a child is skipped
+        entirely (first-wins), keeping the hierarchy one level deep.
+        """
+        a = make_category(display_name="A", slug="a")
+        b = make_category(display_name="B", slug="b")
+        c = make_category(display_name="C", slug="c")
+
+        response = test_client.post(
+            "/api/categories/auto-group/apply",
+            json={
+                "groups": [
+                    {"parent": "A", "children": ["B"]},
+                    {"parent": "B", "children": ["C"]},
+                ]
+            },
+        )
+        assert response.status_code == 200
+
+        test_session.refresh(a)
+        test_session.refresh(b)
+        test_session.refresh(c)
+        assert b.parent_id == a.id
+        assert c.parent_id is None  # group with used-as-child parent skipped
+        # No category has a parent that itself has a parent (max depth 1)
+        by_id = {cat.id: cat for cat in (a, b, c)}
+        for cat in by_id.values():
+            if cat.parent_id is not None:
+                assert by_id[cat.parent_id].parent_id is None
+
+    def test_parent_slug_never_reassigned_as_child(
+        self,
+        test_client: TestClient,
+        test_session: Session,
+        make_category: Callable[..., Category],
+    ):
+        """A slug already used as a parent keeps its children; a later group
+        listing it as a child skips that assignment (first-wins)."""
+        a = make_category(display_name="A", slug="a")
+        b = make_category(display_name="B", slug="b")
+        c = make_category(display_name="C", slug="c")
+
+        response = test_client.post(
+            "/api/categories/auto-group/apply",
+            json={
+                "groups": [
+                    {"parent": "B", "children": ["C"]},
+                    {"parent": "A", "children": ["B"]},
+                ]
+            },
+        )
+        assert response.status_code == 200
+
+        test_session.refresh(a)
+        test_session.refresh(b)
+        test_session.refresh(c)
+        assert c.parent_id == b.id  # B keeps its children
+        assert b.parent_id is None  # second assignment of B skipped
+        assert a.parent_id is None
+
     def test_skips_nonexistent_category_names(
         self,
         test_client: TestClient,

--- a/backend/tests/test_category_aliases.py
+++ b/backend/tests/test_category_aliases.py
@@ -188,7 +188,8 @@ class TestMergeAliases:
         assert resp.status_code == 200
         body = resp.json()
         assert body["ok"] is True
-        assert body["articles_moved"] == 2
+        # a1 moved (link created on target); a2 already on target -> deduped
+        assert body["articles_moved"] == 1
         assert body["aliases_repointed"] == 1
         assert body["children_released"] == [
             {"id": child_id, "display_name": "Bitcoin"}

--- a/backend/tests/test_category_aliases.py
+++ b/backend/tests/test_category_aliases.py
@@ -1,0 +1,321 @@
+"""Alias lifecycle side effects on category verbs (ADR-0007).
+
+Rename leaves an alias from the old slug; merge repoints the source's
+aliases and leaves one for its own name; delete (single and batch)
+leaves a discard alias; explicit create/rename onto an aliased name
+erases that alias. Also covers the one-level shelf enforcement gap in
+PATCH parent_id.
+"""
+
+from sqlmodel import select
+
+from backend.models import ArticleCategoryLink, Category, CategoryAlias
+from backend.scoring import resolve_proposal
+
+
+def _aliases(session) -> list[CategoryAlias]:
+    return session.exec(select(CategoryAlias)).all()
+
+
+def _alias_for(session, slug: str) -> CategoryAlias | None:
+    return session.exec(
+        select(CategoryAlias).where(CategoryAlias.alias_slug == slug)
+    ).first()
+
+
+# ---------------------------------------------------------------------------
+# Rename
+# ---------------------------------------------------------------------------
+
+
+class TestRenameAliases:
+    def test_rename_creates_alias_and_old_name_resolves(
+        self, test_client, test_session, make_category
+    ):
+        cat = make_category(display_name="Machine Learning", slug="machine-learning")
+
+        resp = test_client.patch(
+            f"/api/categories/{cat.id}", json={"display_name": "AI"}
+        )
+        assert resp.status_code == 200
+        test_session.expire_all()
+
+        alias = _alias_for(test_session, "machine-learning")
+        assert alias is not None
+        assert alias.target_id == cat.id
+
+        # Alias round-trip: proposing the old name returns the renamed
+        # category without creating a new row.
+        before = len(test_session.exec(select(Category)).all())
+        resolved = resolve_proposal(test_session, "Machine Learning")
+        assert resolved is not None
+        assert resolved.id == cat.id
+        assert resolved.slug == "ai"
+        assert len(test_session.exec(select(Category)).all()) == before
+
+    def test_rename_onto_live_name_409_points_at_merge(
+        self, test_client, make_category
+    ):
+        make_category(display_name="AI", slug="ai")
+        cat = make_category(display_name="Crypto", slug="crypto")
+
+        resp = test_client.patch(
+            f"/api/categories/{cat.id}", json={"display_name": "AI"}
+        )
+        assert resp.status_code == 409
+        assert "merge" in resp.json()["detail"]
+
+    def test_rename_onto_aliased_name_deletes_alias_round_trip(
+        self, test_client, test_session, make_category
+    ):
+        cat = make_category(display_name="AI", slug="ai")
+
+        # A -> B leaves alias ai -> cat
+        resp = test_client.patch(
+            f"/api/categories/{cat.id}",
+            json={"display_name": "Artificial Intelligence"},
+        )
+        assert resp.status_code == 200
+        test_session.expire_all()
+        assert _alias_for(test_session, "ai") is not None
+
+        # B -> A: the alias for "ai" is erased (name is live again), a new
+        # alias for the vacated slug appears — no UNIQUE violation.
+        resp = test_client.patch(
+            f"/api/categories/{cat.id}", json={"display_name": "AI"}
+        )
+        assert resp.status_code == 200
+        test_session.expire_all()
+
+        assert _alias_for(test_session, "ai") is None
+        back_alias = _alias_for(test_session, "artificial-intelligence")
+        assert back_alias is not None
+        assert back_alias.target_id == cat.id
+        assert len(_aliases(test_session)) == 1
+
+    def test_same_slug_rename_creates_no_alias(
+        self, test_client, test_session, make_category
+    ):
+        cat = make_category(display_name="machine learning", slug="machine-learning")
+
+        resp = test_client.patch(
+            f"/api/categories/{cat.id}", json={"display_name": "Machine Learning"}
+        )
+        assert resp.status_code == 200
+        test_session.expire_all()
+
+        assert _aliases(test_session) == []
+
+    def test_rename_old_slug_already_aliased_upserts(
+        self, test_client, test_session, make_category
+    ):
+        # Alias for "crypto" already exists (e.g. old junk pointing nowhere),
+        # then a category is renamed *off* the name "Crypto" — the existing
+        # alias row is repointed, not duplicated.
+        other = make_category(display_name="Finance", slug="finance")
+        test_session.add(CategoryAlias(alias_slug="crypto", target_id=other.id))
+        test_session.commit()
+
+        cat = make_category(display_name="Crypto", slug="crypto")
+        resp = test_client.patch(
+            f"/api/categories/{cat.id}", json={"display_name": "Blockchain"}
+        )
+        assert resp.status_code == 200
+        test_session.expire_all()
+
+        alias = _alias_for(test_session, "crypto")
+        assert alias is not None
+        assert alias.target_id == cat.id
+        assert len(_aliases(test_session)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Create
+# ---------------------------------------------------------------------------
+
+
+class TestCreateErasesAlias:
+    def test_create_with_previously_aliased_name(self, test_client, test_session):
+        test_session.add(CategoryAlias(alias_slug="crypto", target_id=None))
+        test_session.commit()
+
+        resp = test_client.post("/api/categories", json={"display_name": "Crypto"})
+        assert resp.status_code == 201
+        test_session.expire_all()
+
+        assert _alias_for(test_session, "crypto") is None
+        created = test_session.exec(
+            select(Category).where(Category.slug == "crypto")
+        ).first()
+        assert created is not None
+
+
+# ---------------------------------------------------------------------------
+# Merge
+# ---------------------------------------------------------------------------
+
+
+class TestMergeAliases:
+    def test_merge_full_lifecycle(
+        self, test_client, test_session, make_category, make_feed, make_article
+    ):
+        source = make_category(display_name="Crypto", slug="crypto")
+        target = make_category(
+            display_name="Finance", slug="finance", weight="boost", needs_triage=False
+        )
+        child = make_category(
+            display_name="Bitcoin", slug="bitcoin", parent_id=source.id
+        )
+        source_id, target_id, child_id = source.id, target.id, child.id
+
+        # Pre-existing alias pointing at the source must be repointed, not
+        # degraded to a discard by ON DELETE SET NULL.
+        test_session.add(CategoryAlias(alias_slug="web3", target_id=source.id))
+        test_session.commit()
+
+        feed = make_feed()
+        a1 = make_article(feed.id)  # only in source -> moved
+        a2 = make_article(feed.id)  # in both -> deduped
+        test_session.add(ArticleCategoryLink(article_id=a1.id, category_id=source.id))
+        test_session.add(ArticleCategoryLink(article_id=a2.id, category_id=source.id))
+        test_session.add(ArticleCategoryLink(article_id=a2.id, category_id=target.id))
+        test_session.commit()
+
+        resp = test_client.post(
+            "/api/categories/merge",
+            json={"source_id": source_id, "target_id": target_id},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["articles_moved"] == 2
+        assert body["aliases_repointed"] == 1
+        assert body["children_released"] == [
+            {"id": child_id, "display_name": "Bitcoin"}
+        ]
+        test_session.expire_all()
+
+        # Source gone, alias for its name points at the target.
+        assert test_session.get(Category, source_id) is None
+        source_alias = _alias_for(test_session, "crypto")
+        assert source_alias is not None
+        assert source_alias.target_id == target_id
+
+        # Pre-existing alias repointed to target (not a discard).
+        web3_alias = _alias_for(test_session, "web3")
+        assert web3_alias is not None
+        assert web3_alias.target_id == target_id
+
+        # Proposal ladder: both old names resolve to the target.
+        assert resolve_proposal(test_session, "Crypto").id == target_id
+        assert resolve_proposal(test_session, "Web3").id == target_id
+
+        # Children released to root — NOT reparented under the target.
+        assert test_session.get(Category, child_id).parent_id is None
+
+        # Articles moved with dedup.
+        target_links = test_session.exec(
+            select(ArticleCategoryLink).where(
+                ArticleCategoryLink.category_id == target_id
+            )
+        ).all()
+        assert sorted(link.article_id for link in target_links) == sorted(
+            [a1.id, a2.id]
+        )
+
+        # Target itself is never edited.
+        refreshed_target = test_session.get(Category, target_id)
+        assert refreshed_target.weight == "boost"
+        assert refreshed_target.needs_triage is False
+        assert refreshed_target.parent_id is None
+
+    def test_merge_upserts_when_source_slug_already_aliased(
+        self, test_client, test_session, make_category
+    ):
+        source = make_category(display_name="Crypto", slug="crypto")
+        target = make_category(display_name="Finance", slug="finance")
+        test_session.add(CategoryAlias(alias_slug="crypto", target_id=source.id))
+        test_session.commit()
+
+        resp = test_client.post(
+            "/api/categories/merge",
+            json={"source_id": source.id, "target_id": target.id},
+        )
+        assert resp.status_code == 200
+        test_session.expire_all()
+
+        aliases = _aliases(test_session)
+        assert len(aliases) == 1
+        assert aliases[0].alias_slug == "crypto"
+        assert aliases[0].target_id == target.id
+
+
+# ---------------------------------------------------------------------------
+# Delete
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteDiscardAliases:
+    def test_delete_leaves_discard_alias(
+        self, test_client, test_session, make_category
+    ):
+        cat = make_category(display_name="Junk", slug="junk")
+
+        resp = test_client.delete(f"/api/categories/{cat.id}")
+        assert resp.status_code == 200
+        test_session.expire_all()
+
+        alias = _alias_for(test_session, "junk")
+        assert alias is not None
+        assert alias.target_id is None
+
+        # Proposal of the deleted name is discarded — no row created.
+        before = len(test_session.exec(select(Category)).all())
+        assert resolve_proposal(test_session, "Junk") is None
+        assert len(test_session.exec(select(Category)).all()) == before
+
+    def test_batch_delete_leaves_discard_aliases(
+        self, test_client, test_session, make_category
+    ):
+        a = make_category(display_name="Junk A", slug="junk-a")
+        b = make_category(display_name="Junk B", slug="junk-b")
+
+        resp = test_client.post(
+            "/api/categories/batch-delete", json={"category_ids": [a.id, b.id]}
+        )
+        assert resp.status_code == 200
+        test_session.expire_all()
+
+        for slug in ("junk-a", "junk-b"):
+            alias = _alias_for(test_session, slug)
+            assert alias is not None
+            assert alias.target_id is None
+
+
+# ---------------------------------------------------------------------------
+# PATCH parent_id one-level enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestPatchParentOneLevel:
+    def test_parenting_under_non_root_400(self, test_client, make_category):
+        root = make_category(display_name="Root", slug="root")
+        shelf = make_category(display_name="Shelf", slug="shelf", parent_id=root.id)
+        cat = make_category(display_name="Leaf", slug="leaf")
+
+        resp = test_client.patch(
+            f"/api/categories/{cat.id}", json={"parent_id": shelf.id}
+        )
+        assert resp.status_code == 400
+        assert "root" in resp.json()["detail"].lower()
+
+    def test_parenting_category_with_children_400(self, test_client, make_category):
+        parent = make_category(display_name="Parent", slug="parent")
+        make_category(display_name="Kid", slug="kid", parent_id=parent.id)
+        new_root = make_category(display_name="New Root", slug="new-root")
+
+        resp = test_client.patch(
+            f"/api/categories/{parent.id}", json={"parent_id": new_root.id}
+        )
+        assert resp.status_code == 400
+        assert "children" in resp.json()["detail"]

--- a/backend/tests/test_category_management_api.py
+++ b/backend/tests/test_category_management_api.py
@@ -163,6 +163,28 @@ class TestBulkPatch:
 
 
 # ---------------------------------------------------------------------------
+# Create: one-level hierarchy enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestCreateOneLevel:
+    def test_create_under_child_returns_400(
+        self,
+        test_client: TestClient,
+        make_category: Callable[..., Category],
+    ):
+        root = make_category(display_name="Root", slug="root")
+        child = make_category(display_name="Child", slug="child", parent_id=root.id)
+
+        resp = test_client.post(
+            "/api/categories",
+            json={"display_name": "Grandchild", "parent_id": child.id},
+        )
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Target must be a root category (no parent)"
+
+
+# ---------------------------------------------------------------------------
 # Triage list filter
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_category_management_api.py
+++ b/backend/tests/test_category_management_api.py
@@ -1,0 +1,410 @@
+"""Acceptance-criteria tests for issue #91's additive category API surface.
+
+Covers the bulk collection PATCH (triage gestures), the needs_triage
+list filter, the read-only alias listing, block short-circuit visibility
+after a bulk weight change, and the invariant that regrouping (auto-group
+apply, batch-move) touches only parent_id — never weights or article links.
+"""
+
+from collections.abc import Callable
+from datetime import datetime
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from backend.models import Article, ArticleCategoryLink, Category
+from backend.scoring import is_blocked
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _link(session: Session, article_id: int, category_id: int) -> None:
+    session.add(ArticleCategoryLink(article_id=article_id, category_id=category_id))
+    session.commit()
+
+
+def _links(session: Session) -> set[tuple[int, int]]:
+    rows = session.exec(select(ArticleCategoryLink)).all()
+    return {(row.article_id, row.category_id) for row in rows}
+
+
+def _weights(session: Session) -> dict[int, tuple[str, bool]]:
+    cats = session.exec(select(Category)).all()
+    return {c.id: (c.weight, c.needs_triage) for c in cats}
+
+
+# ---------------------------------------------------------------------------
+# Bulk collection PATCH
+# ---------------------------------------------------------------------------
+
+
+class TestBulkPatch:
+    def test_weight_only_updates_all_in_one_call(
+        self,
+        test_client: TestClient,
+        test_session: Session,
+        make_category: Callable[..., Category],
+    ):
+        cats = [make_category() for _ in range(3)]
+
+        resp = test_client.patch(
+            "/api/categories",
+            json={"category_ids": [c.id for c in cats], "weight": "reduce"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["updated"] == 3
+        assert body["missing_ids"] == []
+
+        test_session.expire_all()
+        for cat in cats:
+            fresh = test_session.get(Category, cat.id)
+            assert fresh.weight == "reduce"
+            # weight-only PATCH must not touch triage state
+            assert fresh.needs_triage is False
+
+    def test_needs_triage_only_keep_gesture(
+        self,
+        test_client: TestClient,
+        test_session: Session,
+        make_category: Callable[..., Category],
+    ):
+        cats = [make_category(needs_triage=True) for _ in range(2)]
+
+        resp = test_client.patch(
+            "/api/categories",
+            json={"category_ids": [c.id for c in cats], "needs_triage": False},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["updated"] == 2
+
+        test_session.expire_all()
+        for cat in cats:
+            fresh = test_session.get(Category, cat.id)
+            assert fresh.needs_triage is False
+            # keep gesture must not touch weight
+            assert fresh.weight == "normal"
+
+    def test_both_fields_batch_block_gesture(
+        self,
+        test_client: TestClient,
+        test_session: Session,
+        make_category: Callable[..., Category],
+    ):
+        cats = [make_category(needs_triage=True) for _ in range(2)]
+
+        resp = test_client.patch(
+            "/api/categories",
+            json={
+                "category_ids": [c.id for c in cats],
+                "weight": "block",
+                "needs_triage": False,
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["updated"] == 2
+
+        test_session.expire_all()
+        for cat in cats:
+            fresh = test_session.get(Category, cat.id)
+            assert fresh.weight == "block"
+            assert fresh.needs_triage is False
+
+    def test_missing_ids_reported_while_existing_update(
+        self,
+        test_client: TestClient,
+        test_session: Session,
+        make_category: Callable[..., Category],
+    ):
+        cat = make_category()
+
+        resp = test_client.patch(
+            "/api/categories",
+            json={"category_ids": [cat.id, 9999, 8888], "weight": "boost"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["updated"] == 1
+        assert sorted(body["missing_ids"]) == [8888, 9999]
+
+        test_session.expire_all()
+        assert test_session.get(Category, cat.id).weight == "boost"
+
+    def test_no_fields_provided_422(
+        self,
+        test_client: TestClient,
+        make_category: Callable[..., Category],
+    ):
+        cat = make_category()
+
+        resp = test_client.patch("/api/categories", json={"category_ids": [cat.id]})
+        assert resp.status_code == 422
+
+    def test_invalid_weight_422(
+        self,
+        test_client: TestClient,
+        test_session: Session,
+        make_category: Callable[..., Category],
+    ):
+        cat = make_category()
+
+        resp = test_client.patch(
+            "/api/categories",
+            json={"category_ids": [cat.id], "weight": "banished"},
+        )
+        assert resp.status_code == 422
+
+        test_session.expire_all()
+        assert test_session.get(Category, cat.id).weight == "normal"
+
+
+# ---------------------------------------------------------------------------
+# Triage list filter
+# ---------------------------------------------------------------------------
+
+
+class TestTriageListFilter:
+    @pytest.fixture(name="triage_setup")
+    def triage_setup_fixture(
+        self, test_session, make_category, make_article, make_feed
+    ):
+        feed = make_feed()
+        flagged = make_category(needs_triage=True)
+        settled = make_category(needs_triage=False)
+        article = make_article(feed.id)
+        _link(test_session, article.id, flagged.id)
+        return flagged, settled
+
+    def test_needs_triage_true_returns_only_flagged_with_counts(
+        self, test_client: TestClient, triage_setup
+    ):
+        flagged, _settled = triage_setup
+
+        resp = test_client.get("/api/categories", params={"needs_triage": True})
+        assert resp.status_code == 200
+        items = resp.json()
+        assert [item["id"] for item in items] == [flagged.id]
+        assert items[0]["needs_triage"] is True
+        assert items[0]["article_count"] == 1
+
+    def test_needs_triage_false_returns_the_rest(
+        self, test_client: TestClient, triage_setup
+    ):
+        _flagged, settled = triage_setup
+
+        resp = test_client.get("/api/categories", params={"needs_triage": False})
+        assert resp.status_code == 200
+        items = resp.json()
+        assert [item["id"] for item in items] == [settled.id]
+        assert items[0]["article_count"] == 0
+
+    def test_no_param_returns_all(self, test_client: TestClient, triage_setup):
+        flagged, settled = triage_setup
+
+        resp = test_client.get("/api/categories")
+        assert resp.status_code == 200
+        assert {item["id"] for item in resp.json()} == {flagged.id, settled.id}
+
+
+# ---------------------------------------------------------------------------
+# Alias listing
+# ---------------------------------------------------------------------------
+
+
+class TestAliasListing:
+    def test_lists_redirect_and_discard_aliases(
+        self,
+        test_client: TestClient,
+        make_category: Callable[..., Category],
+    ):
+        source = make_category(display_name="ML", slug="ml")
+        target = make_category(display_name="AI", slug="ai")
+        junk = make_category(display_name="Junk", slug="junk")
+
+        # Merge leaves a redirect alias ml -> AI
+        resp = test_client.post(
+            "/api/categories/merge",
+            json={"source_id": source.id, "target_id": target.id},
+        )
+        assert resp.status_code == 200
+
+        # Delete leaves a discard alias junk -> None
+        resp = test_client.delete(f"/api/categories/{junk.id}")
+        assert resp.status_code == 200
+
+        resp = test_client.get("/api/categories/aliases")
+        assert resp.status_code == 200
+        aliases = {item["alias_slug"]: item for item in resp.json()}
+        assert set(aliases) == {"ml", "junk"}
+
+        redirect = aliases["ml"]
+        assert redirect["target_id"] == target.id
+        assert redirect["target_display_name"] == "AI"
+        assert redirect["id"] is not None
+        assert datetime.fromisoformat(redirect["created_at"])
+
+        discard = aliases["junk"]
+        assert discard["target_id"] is None
+        assert discard["target_display_name"] is None
+
+    def test_empty_when_no_aliases(self, test_client: TestClient):
+        resp = test_client.get("/api/categories/aliases")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+# ---------------------------------------------------------------------------
+# Block short-circuit visibility after bulk PATCH
+# ---------------------------------------------------------------------------
+
+
+class TestBlockShortCircuitAfterBulkPatch:
+    @pytest.mark.asyncio
+    async def test_bulk_blocked_category_routes_article_to_blocked_view(
+        self, test_client, test_session, sample_feed, fake_llm, make_category
+    ):
+        from backend.prompts import ArticleCategoryResult, BatchCategoryResponse
+        from backend.scoring_queue import CategorizationWorker, ScoringWorker
+
+        crypto = make_category(display_name="Crypto", slug="crypto")
+
+        # Block via the bulk collection PATCH (batch-block gesture)
+        resp = test_client.patch(
+            "/api/categories",
+            json={
+                "category_ids": [crypto.id],
+                "weight": "block",
+                "needs_triage": False,
+            },
+        )
+        assert resp.status_code == 200
+        test_session.expire_all()
+        assert is_blocked([test_session.get(Category, crypto.id)])
+
+        article = Article(
+            feed_id=sample_feed.id,
+            title="Coin of the day",
+            url="https://example.com/coin",
+            published_at=datetime.now(),
+            content="Content",
+            categorization_state="queued",
+            scoring_state="unscored",
+        )
+        test_session.add(article)
+        test_session.commit()
+        test_session.refresh(article)
+
+        fake_llm.queue(
+            "categorization",
+            BatchCategoryResponse(
+                results=[
+                    ArticleCategoryResult(
+                        article_id=article.id,
+                        categories=["Crypto"],
+                        proposed_category=None,
+                    )
+                ]
+            ),
+        )
+
+        await CategorizationWorker().process_next_batch(test_session, 5)
+        await ScoringWorker().process_next_batch(test_session, 5)
+        test_session.expire_all()
+
+        # Hidden from the default list, inspectable in the blocked view
+        assert test_client.get("/api/articles").json() == []
+        blocked = test_client.get(
+            "/api/articles", params={"scoring_state": "blocked"}
+        ).json()
+        assert len(blocked) == 1
+        assert blocked[0]["id"] == article.id
+        assert blocked[0]["scoring_state"] == "blocked"
+
+
+# ---------------------------------------------------------------------------
+# Regrouping changes nothing (except parent_id)
+# ---------------------------------------------------------------------------
+
+
+class TestRegroupingChangesNothing:
+    @pytest.fixture(name="grouping_setup")
+    def grouping_setup_fixture(
+        self, test_session, make_category, make_article, make_feed
+    ):
+        feed = make_feed()
+        tech = make_category(display_name="Tech", slug="tech", weight="boost")
+        ai = make_category(display_name="AI", slug="ai", weight="max")
+        crypto = make_category(
+            display_name="Crypto", slug="crypto", weight="block", needs_triage=True
+        )
+        chess = make_category(display_name="Chess", slug="chess", weight="reduce")
+
+        a1 = make_article(feed.id)
+        a2 = make_article(feed.id, scoring_state="blocked")
+        _link(test_session, a1.id, ai.id)
+        _link(test_session, a2.id, crypto.id)
+
+        return {"tech": tech, "ai": ai, "crypto": crypto, "chess": chess}
+
+    def test_auto_group_apply_touches_only_parent_id(
+        self, test_client: TestClient, test_session: Session, grouping_setup
+    ):
+        cats = grouping_setup
+        weights_before = _weights(test_session)
+        links_before = _links(test_session)
+        blocked_before = {
+            cid: is_blocked([test_session.get(Category, cid)]) for cid in weights_before
+        }
+
+        resp = test_client.post(
+            "/api/categories/auto-group/apply",
+            json={
+                "groups": [
+                    {"parent": "Tech", "children": ["AI", "Crypto"]},
+                ]
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["categories_moved"] == 2
+        test_session.expire_all()
+
+        # Only parent_id moved
+        assert test_session.get(Category, cats["ai"].id).parent_id == cats["tech"].id
+        assert (
+            test_session.get(Category, cats["crypto"].id).parent_id == cats["tech"].id
+        )
+        assert test_session.get(Category, cats["chess"].id).parent_id is None
+
+        # Weights, triage flags, blocked state, and article links unchanged
+        assert _weights(test_session) == weights_before
+        assert _links(test_session) == links_before
+        for cid, was_blocked in blocked_before.items():
+            assert is_blocked([test_session.get(Category, cid)]) == was_blocked
+
+    def test_batch_move_touches_only_parent_id(
+        self, test_client: TestClient, test_session: Session, grouping_setup
+    ):
+        cats = grouping_setup
+        weights_before = _weights(test_session)
+        links_before = _links(test_session)
+
+        resp = test_client.post(
+            "/api/categories/batch-move",
+            json={
+                "category_ids": [cats["ai"].id, cats["chess"].id],
+                "target_parent_id": cats["tech"].id,
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["updated"] == 2
+        test_session.expire_all()
+
+        assert test_session.get(Category, cats["ai"].id).parent_id == cats["tech"].id
+        assert test_session.get(Category, cats["chess"].id).parent_id == cats["tech"].id
+
+        assert _weights(test_session) == weights_before
+        assert _links(test_session) == links_before

--- a/backend/tests/test_scoring.py
+++ b/backend/tests/test_scoring.py
@@ -3,7 +3,7 @@
 import pytest
 
 from backend.config import get_settings
-from backend.models import Category, CategoryWeight
+from backend.models import Category
 from backend.scoring import compute_composite_score, is_blocked
 
 
@@ -105,25 +105,6 @@ def test_composite_score_uses_config_boost(custom_boost_multiplier):
     # quality=10 -> quality_mult = 1.0; boost overridden to 3.0
     score = compute_composite_score(4, 10, [cat])
     assert score == 4 * 3.0 * 1.0
-
-
-def test_weight_multiplier_config_defaults():
-    """Defaults match the historical hardcoded multipliers."""
-    multipliers = get_settings().scoring.weight_multipliers
-    assert multipliers.reduce == 0.5
-    assert multipliers.boost == 1.5
-    assert multipliers.max == 2.0
-
-
-def test_category_weight_enum_vocabulary():
-    """CategoryWeight is the single source of the weight vocabulary."""
-    assert [w.value for w in CategoryWeight] == [
-        "block",
-        "reduce",
-        "normal",
-        "boost",
-        "max",
-    ]
 
 
 # --- is_blocked ---

--- a/backend/tests/test_scoring.py
+++ b/backend/tests/test_scoring.py
@@ -1,6 +1,9 @@
 """Unit tests for scoring pure functions (no DB needed)."""
 
-from backend.models import Category
+import pytest
+
+from backend.config import get_settings
+from backend.models import Category, CategoryWeight
 from backend.scoring import compute_composite_score, is_blocked
 
 
@@ -48,6 +51,14 @@ def test_composite_score_boost_weight():
     assert score == 8 * 1.5 * 1.0
 
 
+def test_composite_score_reduce_weight():
+    """Reduce weight: interest * 0.5 * quality_mult (default multiplier)."""
+    cat = _make_category(weight="reduce")
+    # quality=10 -> quality_mult = 1.0
+    score = compute_composite_score(8, 10, [cat])
+    assert score == 8 * 0.5 * 1.0
+
+
 def test_composite_score_empty_categories():
     """No categories: uses default multiplier 1.0."""
     score = compute_composite_score(8, 7, [])
@@ -73,6 +84,46 @@ def test_composite_score_parent_weight_never_inherited():
     child.parent = parent  # type: ignore[assignment]
     score = compute_composite_score(8, 10, [child])
     assert score == 8 * 1.0 * 1.0
+
+
+# --- config-driven multipliers ---
+
+
+@pytest.fixture
+def custom_boost_multiplier(monkeypatch: pytest.MonkeyPatch):
+    """Override scoring.weight_multipliers.boost via env, clearing the
+    settings cache so the override is visible and reverted afterwards."""
+    monkeypatch.setenv("SCORING__WEIGHT_MULTIPLIERS__BOOST", "3.0")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def test_composite_score_uses_config_boost(custom_boost_multiplier):
+    """Boost multiplier comes from config, not a hardcoded table."""
+    cat = _make_category(weight="boost")
+    # quality=10 -> quality_mult = 1.0; boost overridden to 3.0
+    score = compute_composite_score(4, 10, [cat])
+    assert score == 4 * 3.0 * 1.0
+
+
+def test_weight_multiplier_config_defaults():
+    """Defaults match the historical hardcoded multipliers."""
+    multipliers = get_settings().scoring.weight_multipliers
+    assert multipliers.reduce == 0.5
+    assert multipliers.boost == 1.5
+    assert multipliers.max == 2.0
+
+
+def test_category_weight_enum_vocabulary():
+    """CategoryWeight is the single source of the weight vocabulary."""
+    assert [w.value for w in CategoryWeight] == [
+        "block",
+        "reduce",
+        "normal",
+        "boost",
+        "max",
+    ]
 
 
 # --- is_blocked ---

--- a/config/app.yaml
+++ b/config/app.yaml
@@ -12,6 +12,14 @@ logging:
 scheduler:
   log_job_execution: false
 
+# Category weight multipliers used in composite scoring. Defaults shown
+# below; 'normal' (1.0) and 'block' (article suppressed) are fixed in code.
+# scoring:
+#   weight_multipliers:
+#     reduce: 0.5
+#     boost: 1.5
+#     max: 2.0
+
 # Azure OpenAI task routing (endpoint/key come from env:
 # AZURE_OPENAI_ENDPOINT / AZURE_OPENAI_API_KEY)
 llm:

--- a/docs/adr/0007-alias-lifecycle.md
+++ b/docs/adr/0007-alias-lifecycle.md
@@ -1,0 +1,15 @@
+# Alias lifecycle: verbs write alias memory, explicit creation erases it
+
+Aliases (ADR-0001) are written and erased as side effects of category verbs — never managed directly. Rename always leaves an alias from the old slug to the category. Merge repoints the source's existing aliases to the target before deleting the source, then leaves an alias for the source's own name — resolution stays single-hop forever, no chains. Delete (single and batch) always leaves a discard alias (`target_id NULL`), so removed junk stays dead. Explicitly creating a category whose slug matches an alias — or renaming one onto it — deletes that alias: a deliberate human act overrides remembered names.
+
+## Why
+
+- **No flags, no options**: every verb has exactly one alias behavior, so the user never decides "leave an alias?" per action. A harmless extra alias beats a resurrected junk name; the resolution ladder checks live categories first, so a stale alias can never shadow a real one.
+- **Merge repoints explicitly rather than relying on `ON DELETE SET NULL`**: letting the FK degrade the source's aliases would silently turn redirects into discards — proposals of "Artificial Intelligence" would be dropped instead of landing on the merge survivor. `SET NULL` remains only as the safety net for raw deletes, where discard is the correct meaning.
+- **Aliases target ids, not names**: renames never invalidate existing aliases, and repointing is an UPDATE, not a rewrite.
+
+## Consequences
+
+- Block is not part of the alias story: it sets weight only, and the category stays live in the vocabulary (ADR-0001).
+- Rename onto a live category's name is refused (409) and pointed at merge — the two verbs stay distinct.
+- Aliases are user-visible read-only (list endpoint) for auditability, but have no CRUD of their own; the only way to remove one is to create or rename a category onto its name.


### PR DESCRIPTION
# v2: category management rework — triage verbs, aliases, groups (#91)

## What is this PR about?

Implements the category-management API around the v2 model (closes #91): triage verbs riding on CRUD semantics, alias memory on rename/merge/delete, weight multipliers single-sourced in config, display-only groups with the one-level rule enforced everywhere, bulk weight/triage editing, and a queryable new-category triage list.

## Why is this change needed?

v1's category vocabulary drifted out of user control — junk names came back after deletion, weights sat on an unstable foundation, and suppression semantics were scattered. This lands the backend half of the reworked model (ADR-0001/0007) so cleanup is deterministic and regrouping can never change filtering.

## How is this change implemented?

- `CategoryWeight(StrEnum)` is the single weight-enum definition; multipliers (reduce/boost/max) live in `scoring.weight_multipliers` config with `normal`/`block` pinned structurally (block is a short-circuit, not a multiplier)
- Alias lifecycle per ADR-0007: rename always aliases, merge explicitly repoints the source's aliases (never relies on `ON DELETE SET NULL`), delete leaves a discard alias, explicit creation erases remembered names
- Merge releases children to root and reports `children_released` + `aliases_repointed` in a typed response
- New surface: `GET /api/categories?needs_triage=true`, bulk `PATCH /api/categories` (weight/triage in one call), read-only `GET /api/categories/aliases`
- Adversarial code review (8 finder angles + verify pass) caught and fixed 4 issues, incl. two one-level invariant holes; pyright baseline zeroed as a rider

## How to test this change?

1. From `backend/`, run `uv run pytest` — 223 tests should pass (alias round-trips, block short-circuit visibility, and regrouping-changes-nothing invariants included)
2. Start the dev server, create a few categories, then rename one — `GET /api/categories/aliases` shows the old name pointing at the survivor
3. Merge one category into another — the response lists released children; re-proposing the merged name via categorization lands on the survivor and creates no row
4. Select several categories and `PATCH /api/categories` with `{"category_ids": [...], "weight": "block"}` — the articles route to the blocked view
5. Run auto-group suggest/apply — weights and filtering outcomes are unchanged, only shelving moves

## Notes

- Reviewer focus: the alias repointing in `merge_categories` and the depth guards in `auto_group_apply` (both were review findings)
- v1-shaped endpoints (`mark-seen`, `batch-move`, etc.) and `effective_weight` are deliberately kept for milestone-2 validation with the v1 UI; reshape debt is recorded on #98
- No migration needed — the `CategoryAlias` table landed in #90; stored weight values are unchanged
- New config keys are optional; existing deployments run on defaults. Unknown keys under `weight_multipliers` now fail at startup by design

🤖 Generated with [Claude Code](https://claude.com/claude-code)