### PR TITLE
v2: article list + reader, phone-first

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -47,9 +47,9 @@ paths: ["frontend/**"]
 
 - Load-more pagination, not infinite scroll.
 - Unread-first default view, sorted by composite score descending.
-- Mark-as-read timing is re-decided by the milestone-4 reader prototype (see PRD #88) — keep the auto-mark intent, no fixed number yet.
+- Mark-as-read: dwell-based auto-mark, 3s after the reader's content loads (#94 decision) — never auto-mark unread.
 - Full opacity + accent dot for unread, 0.6 opacity + hollow dot for read.
-- **Inter** for UI text (`--font-sans`), **Lora** for reader content (`--font-serif`), via `next/font` + `@theme inline` mapping.
+- **Inter** for UI text (`--font-sans`), **Lora** for reader content and article headlines (#94 decision: list rows + reader titles are serif) (`--font-serif`), via `next/font` + `@theme inline` mapping.
 
 ## Testing
 

--- a/backend/src/backend/deps.py
+++ b/backend/src/backend/deps.py
@@ -3,10 +3,11 @@
 import logging
 from datetime import datetime
 
+from sqlalchemy import ColumnElement
 from sqlmodel import Session, select
 
 from backend.database import engine
-from backend.models import UserPreferences
+from backend.models import Article, UserPreferences
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +20,43 @@ def get_session():
     """FastAPI dependency for database sessions."""
     with Session(engine) as session:
         yield session
+
+
+def unread_condition() -> ColumnElement[bool]:
+    """The single definition of "unread": scored, non-blocked, positive score, unread.
+
+    Shared by the articles list/counts endpoints and the feeds/feed-folders
+    unread_count aggregates so there is exactly one definition in the codebase.
+    """
+    return (
+        (Article.is_read.is_(False))  # pyright: ignore[reportAttributeAccessIssue]
+        & (Article.scoring_state == "scored")
+        & (Article.composite_score > 0)  # pyright: ignore[reportOptionalOperand]
+    )
+
+
+def read_condition() -> ColumnElement[bool]:
+    """Scored, non-blocked, positive-score articles that have been read."""
+    return (
+        (Article.is_read.is_(True))  # pyright: ignore[reportAttributeAccessIssue]
+        & (Article.scoring_state == "scored")
+        & (Article.composite_score > 0)  # pyright: ignore[reportOptionalOperand]
+    )
+
+
+def scoring_pending_condition() -> ColumnElement[bool]:
+    """Articles awaiting first-time categorization/scoring (excludes re-evaluating)."""
+    return (
+        Article.composite_score.is_(None)  # pyright: ignore[reportAttributeAccessIssue, reportOptionalMemberAccess]
+    ) & (
+        Article.scoring_state.in_(["unscored", "queued", "scoring"])  # pyright: ignore[reportAttributeAccessIssue]
+        | Article.categorization_state.in_(["queued", "categorizing"])  # pyright: ignore[reportAttributeAccessIssue]
+    )
+
+
+def blocked_condition() -> ColumnElement[bool]:
+    """Articles blocked by a category weight."""
+    return Article.scoring_state == "blocked"  # pyright: ignore[reportReturnType]
 
 
 def get_or_create_preferences(session: Session) -> UserPreferences:

--- a/backend/src/backend/deps.py
+++ b/backend/src/backend/deps.py
@@ -23,25 +23,23 @@ def get_session():
 
 
 def unread_condition() -> ColumnElement[bool]:
-    """The single definition of "unread": scored, non-blocked, positive score, unread.
+    """The single definition of "unread": scored, non-blocked, unread.
 
+    Matches CONTEXT.md's "Unread" entry — blocking is the only suppression
+    axis, so a scored zero-score article is still unread (visible and counted).
     Shared by the articles list/counts endpoints and the feeds/feed-folders
     unread_count aggregates so there is exactly one definition in the codebase.
     """
     return (
-        (Article.is_read.is_(False))  # pyright: ignore[reportAttributeAccessIssue]
-        & (Article.scoring_state == "scored")
-        & (Article.composite_score > 0)  # pyright: ignore[reportOptionalOperand]
-    )
+        Article.is_read.is_(False)  # pyright: ignore[reportAttributeAccessIssue]
+    ) & (Article.scoring_state == "scored")
 
 
 def read_condition() -> ColumnElement[bool]:
-    """Scored, non-blocked, positive-score articles that have been read."""
+    """Scored, non-blocked articles that have been read."""
     return (
-        (Article.is_read.is_(True))  # pyright: ignore[reportAttributeAccessIssue]
-        & (Article.scoring_state == "scored")
-        & (Article.composite_score > 0)  # pyright: ignore[reportOptionalOperand]
-    )
+        Article.is_read.is_(True)  # pyright: ignore[reportAttributeAccessIssue]
+    ) & (Article.scoring_state == "scored")
 
 
 def scoring_pending_condition() -> ColumnElement[bool]:

--- a/backend/src/backend/routers/articles.py
+++ b/backend/src/backend/routers/articles.py
@@ -243,34 +243,33 @@ def get_article_counts(
     Each count is computed from the same condition helpers the list endpoint's
     filters use, so a count always equals what the matching list query returns.
     """
-    scoping = _scoping_conditions(feed_id, folder_id)
-
-    def _count(condition: ColumnElement[bool]) -> int:
-        statement = select(func.count(Article.id)).join(  # pyright: ignore[reportArgumentType]
-            Feed,
-            Feed.id == Article.feed_id,  # pyright: ignore[reportArgumentType]
-        )
-        for scope in scoping:
-            statement = statement.where(scope)
-        statement = statement.where(condition)
-        return session.exec(statement).one()
+    # One scan with conditional aggregates — this endpoint is polled every 10s.
+    statement = select(
+        func.count(Article.id).filter(unread_condition()),  # pyright: ignore[reportArgumentType]
+        func.count(Article.id).filter(read_condition()),  # pyright: ignore[reportArgumentType]
+        func.count(Article.id).filter(scoring_pending_condition()),  # pyright: ignore[reportArgumentType]
+        func.count(Article.id).filter(blocked_condition()),  # pyright: ignore[reportArgumentType]
+    ).join(
+        Feed,
+        Feed.id == Article.feed_id,  # pyright: ignore[reportArgumentType]
+    )
+    for scope in _scoping_conditions(feed_id, folder_id):
+        statement = statement.where(scope)
+    unread, read, scoring, blocked = session.exec(statement).one()
 
     return ArticleCountsResponse(
-        unread=_count(unread_condition()),
-        read=_count(read_condition()),
-        scoring=_count(scoring_pending_condition()),
-        blocked=_count(blocked_condition()),
+        unread=unread,
+        read=read,
+        scoring=scoring,
+        blocked=blocked,
     )
 
 
 @router.post("/mark-all-read")
 def mark_all_read(session: Session = Depends(get_session)):
-    """Mark all unread scored non-blocked articles as read."""
+    """Mark all unread articles read — same definition of unread as counts/badges."""
     result = session.exec(
-        update(Article)
-        .where(Article.is_read.is_(False))  # pyright: ignore[reportAttributeAccessIssue]
-        .where(Article.scoring_state == "scored")  # pyright: ignore[reportArgumentType]
-        .values(is_read=True)
+        update(Article).where(unread_condition()).values(is_read=True)  # pyright: ignore[reportArgumentType]
     )
     session.commit()
     return {"ok": True, "count": result.rowcount}

--- a/backend/src/backend/routers/articles.py
+++ b/backend/src/backend/routers/articles.py
@@ -4,15 +4,23 @@ import re
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import desc, nulls_last, update
+from sqlalchemy import ColumnElement, desc, nulls_last, update
 from sqlalchemy.orm import selectinload
-from sqlmodel import Session, select
+from sqlmodel import Session, func, select
 
-from backend.deps import get_session
+from backend.deps import (
+    blocked_condition,
+    get_session,
+    read_condition,
+    scoring_pending_condition,
+    unread_condition,
+)
 from backend.models import Article, Category, Feed
 from backend.schemas import (
     ArticleCategoryEmbed,
+    ArticleCountsResponse,
     ArticleListItem,
+    ArticleListResponse,
     ArticleResponse,
     ArticleUpdate,
 )
@@ -91,12 +99,13 @@ def _article_to_response(article: Article) -> ArticleResponse:
     )
 
 
-def _article_to_list_item(article: Article) -> ArticleListItem:
+def _article_to_list_item(article: Article, feed_title: str) -> ArticleListItem:
     """Convert an Article with loaded categories_rel to a lightweight list item."""
     display_state, re_eval = _derive_display_state(article)
     return ArticleListItem(
         id=article.id,  # pyright: ignore[reportArgumentType]
         feed_id=article.feed_id,
+        feed_title=feed_title,
         title=article.title,
         url=article.url,
         author=article.author,
@@ -114,7 +123,45 @@ def _article_to_list_item(article: Article) -> ArticleListItem:
     )
 
 
-@router.get("", response_model=list[ArticleListItem])
+def _scoping_conditions(
+    feed_id: int | None, folder_id: int | None
+) -> list[ColumnElement[bool]]:
+    """Conditions scoping a query to a feed or folder — shared by list and counts.
+
+    Callers must join Feed themselves when folder_id is used (the list endpoint
+    already selects Article and joins Feed; the counts endpoint joins Feed too).
+    """
+    conditions: list[ColumnElement[bool]] = []
+    if feed_id is not None:
+        conditions.append(Article.feed_id == feed_id)  # pyright: ignore[reportArgumentType]
+    if folder_id is not None:
+        conditions.append(Feed.folder_id == folder_id)  # pyright: ignore[reportArgumentType]
+    return conditions
+
+
+def _scoring_state_condition(
+    scoring_state: str | None, exclude_blocked: bool
+) -> tuple[ColumnElement[bool] | None, bool]:
+    """The condition for a scoring_state filter value, and the effective exclude_blocked.
+
+    Returns (condition_or_None, exclude_blocked). A None condition means "no
+    scoring_state-specific filter" (exclude_blocked then applies as usual).
+    """
+    if scoring_state == "pending":
+        return scoring_pending_condition(), exclude_blocked
+    if scoring_state == "blocked":
+        return blocked_condition(), False
+    if scoring_state == "failed":
+        return (
+            (Article.scoring_state == "failed")
+            | (Article.categorization_state == "failed")
+        ), False  # pyright: ignore[reportReturnType]
+    if scoring_state is not None:
+        return Article.scoring_state == scoring_state, False  # pyright: ignore[reportReturnType]
+    return None, exclude_blocked
+
+
+@router.get("", response_model=ArticleListResponse)
 def list_articles(
     skip: int = 0,
     limit: int = 50,
@@ -128,40 +175,25 @@ def list_articles(
     session: Session = Depends(get_session),
 ):
     """List articles, paginated and sorted by composite_score or published_at."""
-    statement = select(Article).options(
-        selectinload(Article.categories_rel).joinedload(Category.parent)  # pyright: ignore[reportArgumentType]
+    statement = (
+        select(Article, Feed.title)
+        .join(Feed, Feed.id == Article.feed_id)  # pyright: ignore[reportArgumentType]
+        .options(
+            selectinload(Article.categories_rel).joinedload(Category.parent)  # pyright: ignore[reportArgumentType]
+        )
     )
 
     if is_read is not None:
         statement = statement.where(Article.is_read == is_read)
 
-    if feed_id is not None:
-        statement = statement.where(Article.feed_id == feed_id)
+    for condition in _scoping_conditions(feed_id, folder_id):
+        statement = statement.where(condition)
 
-    if folder_id is not None:
-        statement = statement.join(Feed, Feed.id == Article.feed_id).where(  # pyright: ignore[reportArgumentType]
-            Feed.folder_id == folder_id
-        )
-
-    if scoring_state == "pending":
-        statement = statement.where(
-            Article.composite_score.is_(None),  # pyright: ignore[reportAttributeAccessIssue, reportOptionalMemberAccess]  # first-time only — excludes re-evaluating
-            (
-                Article.scoring_state.in_(["unscored", "queued", "scoring"])  # pyright: ignore[reportAttributeAccessIssue]
-                | Article.categorization_state.in_(["queued", "categorizing"])  # pyright: ignore[reportAttributeAccessIssue]
-            ),
-        )
-    elif scoring_state == "blocked":
-        statement = statement.where(Article.scoring_state == "blocked")
-        exclude_blocked = False
-    elif scoring_state == "failed":
-        statement = statement.where(
-            (Article.scoring_state == "failed")
-            | (Article.categorization_state == "failed")
-        )
-        exclude_blocked = False
-    elif scoring_state is not None:
-        statement = statement.where(Article.scoring_state == scoring_state)
+    state_condition, exclude_blocked = _scoring_state_condition(
+        scoring_state, exclude_blocked
+    )
+    if state_condition is not None:
+        statement = statement.where(state_condition)
 
     if exclude_blocked and scoring_state is None:
         statement = statement.where(Article.scoring_state == "scored")
@@ -187,9 +219,48 @@ def list_articles(
         else:
             statement = statement.order_by(Article.published_at.asc(), Article.id)  # pyright: ignore[reportAttributeAccessIssue, reportOptionalMemberAccess, reportArgumentType]
 
-    statement = statement.offset(skip).limit(limit)
-    articles = session.exec(statement).all()
-    return [_article_to_list_item(article) for article in articles]
+    # Fetch one extra row to determine has_more without a second count query.
+    statement = statement.offset(skip).limit(limit + 1)
+    rows = session.exec(statement).all()
+    has_more = len(rows) > limit
+    rows = rows[:limit]
+    return ArticleListResponse(
+        items=[
+            _article_to_list_item(article, feed_title) for article, feed_title in rows
+        ],
+        has_more=has_more,
+    )
+
+
+@router.get("/counts", response_model=ArticleCountsResponse)
+def get_article_counts(
+    feed_id: int | None = None,
+    folder_id: int | None = None,
+    session: Session = Depends(get_session),
+):
+    """Counts for the four article list views, scoped identically to the list endpoint.
+
+    Each count is computed from the same condition helpers the list endpoint's
+    filters use, so a count always equals what the matching list query returns.
+    """
+    scoping = _scoping_conditions(feed_id, folder_id)
+
+    def _count(condition: ColumnElement[bool]) -> int:
+        statement = select(func.count(Article.id)).join(  # pyright: ignore[reportArgumentType]
+            Feed,
+            Feed.id == Article.feed_id,  # pyright: ignore[reportArgumentType]
+        )
+        for scope in scoping:
+            statement = statement.where(scope)
+        statement = statement.where(condition)
+        return session.exec(statement).one()
+
+    return ArticleCountsResponse(
+        unread=_count(unread_condition()),
+        read=_count(read_condition()),
+        scoring=_count(scoring_pending_condition()),
+        blocked=_count(blocked_condition()),
+    )
 
 
 @router.post("/mark-all-read")

--- a/backend/src/backend/routers/feed_folders.py
+++ b/backend/src/backend/routers/feed_folders.py
@@ -7,7 +7,7 @@ from sqlalchemy import delete
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, func, select
 
-from backend.deps import get_session
+from backend.deps import get_session, unread_condition
 from backend.models import Article, Feed, FeedFolder
 from backend.schemas import (
     FeedFolderCreate,
@@ -39,9 +39,7 @@ def _folder_unread_count(session: Session, folder_id: int) -> int:
         select(func.count(Article.id))  # pyright: ignore[reportArgumentType]
         .join(Feed, Feed.id == Article.feed_id)  # pyright: ignore[reportArgumentType]
         .where(Feed.folder_id == folder_id)
-        .where(Article.is_read.is_(False))  # pyright: ignore[reportAttributeAccessIssue]
-        .where(Article.scoring_state == "scored")
-        .where(Article.composite_score > 0)  # pyright: ignore[reportOptionalOperand]
+        .where(unread_condition())
     ).one()
 
 
@@ -58,10 +56,7 @@ def list_feed_folders(
         .outerjoin(Feed, Feed.folder_id == FeedFolder.id)  # pyright: ignore[reportArgumentType]
         .outerjoin(
             Article,
-            (Article.feed_id == Feed.id)
-            & (Article.is_read.is_(False))  # pyright: ignore[reportAttributeAccessIssue]
-            & (Article.scoring_state == "scored")
-            & (Article.composite_score > 0),  # pyright: ignore[reportOptionalOperand]
+            (Article.feed_id == Feed.id) & unread_condition(),  # pyright: ignore[reportOperatorIssue]
         )
         .group_by(FeedFolder.id)  # pyright: ignore[reportArgumentType]
         .order_by(FeedFolder.display_order, FeedFolder.id)  # pyright: ignore[reportArgumentType]

--- a/backend/src/backend/routers/feeds.py
+++ b/backend/src/backend/routers/feeds.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import update
 from sqlmodel import Session, func, select
 
-from backend.deps import get_session
+from backend.deps import get_session, unread_condition
 from backend.feeds import fetch_feed, refresh_feed, save_articles
 from backend.models import Article, Feed, FeedFolder
 from backend.schemas import (
@@ -41,10 +41,7 @@ def list_feeds(
         .outerjoin(FeedFolder, FeedFolder.id == Feed.folder_id)  # pyright: ignore[reportArgumentType]
         .outerjoin(
             Article,
-            (Article.feed_id == Feed.id)
-            & (Article.is_read.is_(False))  # pyright: ignore[reportAttributeAccessIssue]
-            & (Article.scoring_state == "scored")
-            & (Article.composite_score > 0),  # pyright: ignore[reportOptionalOperand]
+            (Article.feed_id == Feed.id) & unread_condition(),  # pyright: ignore[reportOperatorIssue]
         )
         .group_by(Feed.id, FeedFolder.name)  # pyright: ignore[reportArgumentType]
         .order_by(Feed.folder_id, Feed.display_order, Feed.id)  # pyright: ignore[reportArgumentType]
@@ -297,9 +294,7 @@ def update_feed(
     unread_count = session.exec(
         select(func.count(Article.id))  # pyright: ignore[reportArgumentType]
         .where(Article.feed_id == feed.id)
-        .where(Article.is_read.is_(False))  # pyright: ignore[reportAttributeAccessIssue]
-        .where(Article.scoring_state == "scored")
-        .where(Article.composite_score > 0)  # pyright: ignore[reportOptionalOperand]
+        .where(unread_condition())
     ).one()
 
     folder_name = None

--- a/backend/src/backend/routers/feeds.py
+++ b/backend/src/backend/routers/feeds.py
@@ -132,13 +132,21 @@ async def create_feed(
 
         categorization_worker.enqueue_articles(session, new_article_ids)
 
+    # unread_count uses the shared definition (scored, score > 0), not the raw
+    # fetch count — freshly fetched articles are unscored, so this is 0 here.
+    unread_count = session.exec(
+        select(func.count(Article.id))  # pyright: ignore[reportArgumentType]
+        .where(Article.feed_id == feed.id)
+        .where(unread_condition())
+    ).one()
+
     return FeedResponse(
         id=feed.id,  # pyright: ignore[reportArgumentType]
         url=feed.url,
         title=feed.title,
         display_order=feed.display_order,
         last_fetched_at=feed.last_fetched_at,
-        unread_count=article_count,
+        unread_count=unread_count,
         folder_id=feed.folder_id,
         folder_name=None,
     )

--- a/backend/src/backend/schemas.py
+++ b/backend/src/backend/schemas.py
@@ -40,6 +40,7 @@ class ArticleListItem(BaseModel):
 
     id: int
     feed_id: int
+    feed_title: str
     title: str
     url: str
     author: str | None
@@ -54,6 +55,22 @@ class ArticleListItem(BaseModel):
     scoring_state: str
     scored_at: datetime | None
     re_evaluating: bool = False
+
+
+class ArticleListResponse(BaseModel):
+    """Envelope for the paginated article list endpoint."""
+
+    items: list[ArticleListItem]
+    has_more: bool
+
+
+class ArticleCountsResponse(BaseModel):
+    """Counts for the four article list views, scoped identically to the list endpoint."""
+
+    unread: int
+    read: int
+    scoring: int
+    blocked: int
 
 
 class ArticleResponse(BaseModel):

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -17,7 +17,7 @@ def test_list_articles_empty(test_client: TestClient):
     """Test listing articles when database is empty."""
     response = test_client.get("/api/articles")
     assert response.status_code == 200
-    assert response.json() == []
+    assert response.json() == {"items": [], "has_more": False}
 
 
 def test_list_articles_with_data(test_client: TestClient, sample_articles):
@@ -25,7 +25,9 @@ def test_list_articles_with_data(test_client: TestClient, sample_articles):
     response = test_client.get("/api/articles?sort_by=published_at&order=desc")
     assert response.status_code == 200
 
-    articles = response.json()
+    body = response.json()
+    assert body["has_more"] is False
+    articles = body["items"]
     assert len(articles) == 3
 
     # Check ordering: Recent -> Older -> Read (by published_at desc)
@@ -37,13 +39,18 @@ def test_list_articles_with_data(test_client: TestClient, sample_articles):
     assert articles[0]["is_read"] is False
     assert articles[2]["is_read"] is True
 
+    # feed_title populated via join
+    assert articles[0]["feed_title"] == "Test Feed"
+
 
 def test_list_articles_pagination(test_client: TestClient, sample_articles):
     """Test pagination parameters."""
     # Get first article only
     response = test_client.get("/api/articles?limit=1&sort_by=published_at&order=desc")
     assert response.status_code == 200
-    articles = response.json()
+    body = response.json()
+    assert body["has_more"] is True
+    articles = body["items"]
     assert len(articles) == 1
     assert articles[0]["title"] == "Recent Article"
 
@@ -52,9 +59,21 @@ def test_list_articles_pagination(test_client: TestClient, sample_articles):
         "/api/articles?skip=1&limit=1&sort_by=published_at&order=desc"
     )
     assert response.status_code == 200
-    articles = response.json()
+    body = response.json()
+    assert body["has_more"] is True
+    articles = body["items"]
     assert len(articles) == 1
     assert articles[0]["title"] == "Older Article"
+
+    # Last page: no more rows beyond it
+    response = test_client.get(
+        "/api/articles?skip=2&limit=1&sort_by=published_at&order=desc"
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["has_more"] is False
+    assert len(body["items"]) == 1
+    assert body["items"][0]["title"] == "Read Article"
 
 
 def test_list_articles_filter_unread(test_client: TestClient, sample_articles):
@@ -64,7 +83,7 @@ def test_list_articles_filter_unread(test_client: TestClient, sample_articles):
     )
     assert response.status_code == 200
 
-    articles = response.json()
+    articles = response.json()["items"]
     assert len(articles) == 2
 
     # Should return only unread articles
@@ -79,7 +98,7 @@ def test_list_articles_filter_read(test_client: TestClient, sample_articles):
     response = test_client.get("/api/articles?is_read=true")
     assert response.status_code == 200
 
-    articles = response.json()
+    articles = response.json()["items"]
     assert len(articles) == 1
 
     # Should return only read articles
@@ -92,7 +111,7 @@ def test_list_articles_no_filter(test_client: TestClient, sample_articles):
     response = test_client.get("/api/articles")
     assert response.status_code == 200
 
-    articles = response.json()
+    articles = response.json()["items"]
     assert len(articles) == 3
 
     # Should return all articles

--- a/backend/tests/test_article_counts.py
+++ b/backend/tests/test_article_counts.py
@@ -1,0 +1,191 @@
+"""Tests for GET /api/articles/counts (issue #94).
+
+The core invariant: every count must equal the row count of the matching
+list-endpoint query, and the global `unread` count must equal the sum of
+`unread_count` across GET /api/feeds (single definition of "unread").
+"""
+
+from fastapi.testclient import TestClient
+
+
+def _seed_mixed_articles(make_feed, make_article):
+    """Seed one feed with a mix of scoring states.
+
+    - 2 unread scored articles with composite_score > 0
+    - 1 read scored article with composite_score > 0
+    - 1 unread scored article with composite_score == 0 (should NOT count as unread)
+    - 1 pending (queued categorization) article
+    - 1 blocked article
+    - 1 failed article
+    """
+    feed = make_feed()
+    unread_scored = [
+        make_article(
+            feed.id,
+            is_read=False,
+            scoring_state="scored",
+            categorization_state="categorized",
+            composite_score=5.0,
+        )
+        for _ in range(2)
+    ]
+    read_scored = make_article(
+        feed.id,
+        is_read=True,
+        scoring_state="scored",
+        categorization_state="categorized",
+        composite_score=5.0,
+    )
+    zero_score_unread = make_article(
+        feed.id,
+        is_read=False,
+        scoring_state="scored",
+        categorization_state="categorized",
+        composite_score=0.0,
+    )
+    pending = make_article(
+        feed.id,
+        is_read=False,
+        scoring_state="unscored",
+        categorization_state="queued",
+        composite_score=None,
+    )
+    blocked = make_article(
+        feed.id,
+        is_read=False,
+        scoring_state="blocked",
+        categorization_state="categorized",
+        composite_score=0.0,
+    )
+    return feed, {
+        "unread_scored": unread_scored,
+        "read_scored": read_scored,
+        "zero_score_unread": zero_score_unread,
+        "pending": pending,
+        "blocked": blocked,
+    }
+
+
+def test_counts_match_list_query_rows(test_client: TestClient, make_feed, make_article):
+    """Each count equals the number of rows the matching list query returns."""
+    _seed_mixed_articles(make_feed, make_article)
+
+    counts = test_client.get("/api/articles/counts").json()
+
+    # The list endpoint's is_read filter alone doesn't exclude score==0 articles
+    # (that's a display nuance, not the unread *count* definition) — so the
+    # matching list query for the "unread" count also asserts composite_score > 0.
+    unread_list = test_client.get("/api/articles", params={"is_read": "false"}).json()
+    unread_rows = [
+        item for item in unread_list["items"] if (item["composite_score"] or 0) > 0
+    ]
+    read_list = test_client.get("/api/articles", params={"is_read": "true"}).json()
+    read_rows = [
+        item for item in read_list["items"] if (item["composite_score"] or 0) > 0
+    ]
+    pending_list = test_client.get(
+        "/api/articles", params={"scoring_state": "pending"}
+    ).json()
+    blocked_list = test_client.get(
+        "/api/articles", params={"scoring_state": "blocked"}
+    ).json()
+
+    assert counts["unread"] == len(unread_rows)
+    assert counts["read"] == len(read_rows)
+    assert counts["scoring"] == len(pending_list["items"])
+    assert counts["blocked"] == len(blocked_list["items"])
+
+    # Explicit expected values given the seeded mix.
+    assert counts["unread"] == 2  # zero-score article excluded
+    assert counts["read"] == 1
+    assert counts["scoring"] == 1
+    assert counts["blocked"] == 1
+
+
+def test_counts_scoped_by_feed_id(test_client: TestClient, make_feed, make_article):
+    """feed_id scopes counts the same way it scopes the list endpoint."""
+    feed_a = make_feed()
+    feed_b = make_feed()
+    make_article(
+        feed_a.id,
+        is_read=False,
+        scoring_state="scored",
+        categorization_state="categorized",
+        composite_score=5.0,
+    )
+    make_article(
+        feed_b.id,
+        is_read=False,
+        scoring_state="scored",
+        categorization_state="categorized",
+        composite_score=5.0,
+    )
+
+    counts_a = test_client.get(
+        "/api/articles/counts", params={"feed_id": feed_a.id}
+    ).json()
+    list_a = test_client.get(
+        "/api/articles", params={"feed_id": feed_a.id, "is_read": "false"}
+    ).json()
+
+    assert counts_a["unread"] == 1
+    assert counts_a["unread"] == len(list_a["items"])
+
+
+def test_counts_scoped_by_folder_id(
+    test_client: TestClient, make_feed, make_article, test_session
+):
+    """folder_id scopes counts the same way it scopes the list endpoint (join through Feed)."""
+    folder_response = test_client.post(
+        "/api/feed-folders", json={"name": "Tech", "feed_ids": []}
+    )
+    folder_id = folder_response.json()["id"]
+
+    feed_in_folder = make_feed(folder_id=folder_id)
+    feed_outside = make_feed()
+
+    make_article(
+        feed_in_folder.id,
+        is_read=False,
+        scoring_state="scored",
+        categorization_state="categorized",
+        composite_score=5.0,
+    )
+    make_article(
+        feed_outside.id,
+        is_read=False,
+        scoring_state="scored",
+        categorization_state="categorized",
+        composite_score=5.0,
+    )
+
+    counts = test_client.get(
+        "/api/articles/counts", params={"folder_id": folder_id}
+    ).json()
+    list_scoped = test_client.get(
+        "/api/articles", params={"folder_id": folder_id, "is_read": "false"}
+    ).json()
+
+    assert counts["unread"] == 1
+    assert counts["unread"] == len(list_scoped["items"])
+
+
+def test_global_unread_count_matches_sum_of_feed_unread_counts(
+    test_client: TestClient, make_feed, make_article
+):
+    """Invariant: counts endpoint's global unread == sum of unread_count across GET /api/feeds."""
+    _seed_mixed_articles(make_feed, make_article)
+    # A second feed with its own unread article to make the sum non-trivial.
+    feed_two = make_feed()
+    make_article(
+        feed_two.id,
+        is_read=False,
+        scoring_state="scored",
+        categorization_state="categorized",
+        composite_score=3.0,
+    )
+
+    counts = test_client.get("/api/articles/counts").json()
+    feeds = test_client.get("/api/feeds").json()
+
+    assert counts["unread"] == sum(feed["unread_count"] for feed in feeds)

--- a/backend/tests/test_article_counts.py
+++ b/backend/tests/test_article_counts.py
@@ -72,17 +72,11 @@ def test_counts_match_list_query_rows(test_client: TestClient, make_feed, make_a
 
     counts = test_client.get("/api/articles/counts").json()
 
-    # The list endpoint's is_read filter alone doesn't exclude score==0 articles
-    # (that's a display nuance, not the unread *count* definition) — so the
-    # matching list query for the "unread" count also asserts composite_score > 0.
+    # Unread is scored + not blocked + not read (CONTEXT.md definition) — a
+    # zero-score scored article is still unread, so the count equals the
+    # unread list rows exactly, with no client-side filtering.
     unread_list = test_client.get("/api/articles", params={"is_read": "false"}).json()
-    unread_rows = [
-        item for item in unread_list["items"] if (item["composite_score"] or 0) > 0
-    ]
     read_list = test_client.get("/api/articles", params={"is_read": "true"}).json()
-    read_rows = [
-        item for item in read_list["items"] if (item["composite_score"] or 0) > 0
-    ]
     pending_list = test_client.get(
         "/api/articles", params={"scoring_state": "pending"}
     ).json()
@@ -90,13 +84,13 @@ def test_counts_match_list_query_rows(test_client: TestClient, make_feed, make_a
         "/api/articles", params={"scoring_state": "blocked"}
     ).json()
 
-    assert counts["unread"] == len(unread_rows)
-    assert counts["read"] == len(read_rows)
+    assert counts["unread"] == len(unread_list["items"])
+    assert counts["read"] == len(read_list["items"])
     assert counts["scoring"] == len(pending_list["items"])
     assert counts["blocked"] == len(blocked_list["items"])
 
     # Explicit expected values given the seeded mix.
-    assert counts["unread"] == 2  # zero-score article excluded
+    assert counts["unread"] == 3  # includes the zero-score scored article
     assert counts["read"] == 1
     assert counts["scoring"] == 1
     assert counts["blocked"] == 1

--- a/backend/tests/test_article_display_state.py
+++ b/backend/tests/test_article_display_state.py
@@ -15,7 +15,7 @@ def test_first_time_categorizing_article_shows_actual_state(
 
     resp = test_client.get("/api/articles", params={"scoring_state": "pending"})
     assert resp.status_code == 200
-    items = resp.json()
+    items = resp.json()["items"]
     assert len(items) == 1
     assert items[0]["scoring_state"] == "queued"
     assert items[0]["re_evaluating"] is False
@@ -36,7 +36,7 @@ def test_re_evaluating_article_shows_as_scored(
     # Should show up in the default (scored) list, not pending
     resp = test_client.get("/api/articles")
     assert resp.status_code == 200
-    items = resp.json()
+    items = resp.json()["items"]
     assert len(items) == 1
     assert items[0]["scoring_state"] == "scored"
     assert items[0]["re_evaluating"] is True
@@ -56,7 +56,7 @@ def test_categorization_failed_shows_as_failed(
 
     resp = test_client.get("/api/articles", params={"scoring_state": "failed"})
     assert resp.status_code == 200
-    items = resp.json()
+    items = resp.json()["items"]
     assert len(items) == 1
     assert items[0]["scoring_state"] == "failed"
 
@@ -85,7 +85,7 @@ def test_pending_filter_excludes_re_evaluating(
 
     resp = test_client.get("/api/articles", params={"scoring_state": "pending"})
     assert resp.status_code == 200
-    items = resp.json()
+    items = resp.json()["items"]
     assert len(items) == 1
     assert items[0]["title"] == "First Timer"
 
@@ -112,7 +112,7 @@ def test_failed_filter_shows_both_cat_and_scoring_failures(
 
     resp = test_client.get("/api/articles", params={"scoring_state": "failed"})
     assert resp.status_code == 200
-    items = resp.json()
+    items = resp.json()["items"]
     titles = {item["title"] for item in items}
     assert titles == {"Cat Failed", "Score Failed"}
 

--- a/backend/tests/test_categorization_api.py
+++ b/backend/tests/test_categorization_api.py
@@ -69,11 +69,11 @@ async def test_blocked_article_in_blocked_view_with_reasoning(
     test_session.expire_all()
 
     # Hidden from the default list.
-    assert test_client.get("/api/articles").json() == []
+    assert test_client.get("/api/articles").json()["items"] == []
 
     blocked = test_client.get(
         "/api/articles", params={"scoring_state": "blocked"}
-    ).json()
+    ).json()["items"]
     assert len(blocked) == 1
     item = blocked[0]
     assert item["id"] == article.id

--- a/backend/tests/test_category_management_api.py
+++ b/backend/tests/test_category_management_api.py
@@ -338,10 +338,10 @@ class TestBlockShortCircuitAfterBulkPatch:
         test_session.expire_all()
 
         # Hidden from the default list, inspectable in the blocked view
-        assert test_client.get("/api/articles").json() == []
+        assert test_client.get("/api/articles").json()["items"] == []
         blocked = test_client.get(
             "/api/articles", params={"scoring_state": "blocked"}
-        ).json()
+        ).json()["items"]
         assert len(blocked) == 1
         assert blocked[0]["id"] == article.id
         assert blocked[0]["scoring_state"] == "blocked"

--- a/backend/tests/test_feed_folders_api.py
+++ b/backend/tests/test_feed_folders_api.py
@@ -250,7 +250,7 @@ def test_articles_can_be_filtered_by_folder(
     )
     assert response.status_code == 200
 
-    data = response.json()
+    data = response.json()["items"]
     assert len(data) == 1
     assert data[0]["id"] == folder_article.id
     assert data[0]["feed_id"] == folder_feed.id

--- a/backend/tests/test_router_smoke.py
+++ b/backend/tests/test_router_smoke.py
@@ -11,10 +11,12 @@ def test_health(test_client: TestClient):
 
 
 def test_articles_list(test_client: TestClient):
-    """GET /api/articles -> 200, returns list."""
+    """GET /api/articles -> 200, returns envelope with items/has_more."""
     response = test_client.get("/api/articles")
     assert response.status_code == 200
-    assert isinstance(response.json(), list)
+    body = response.json()
+    assert isinstance(body["items"], list)
+    assert isinstance(body["has_more"], bool)
 
 
 def test_feeds_list(test_client: TestClient):

--- a/backend/tests/test_scoring_lifecycle.py
+++ b/backend/tests/test_scoring_lifecycle.py
@@ -46,7 +46,7 @@ async def test_full_scoring_lifecycle_visible_via_api(
     # Scored article appears in the default article list with scores
     response = test_client.get("/api/articles")
     assert response.status_code == 200
-    items = response.json()
+    items = response.json()["items"]
     assert len(items) == 1
     item = items[0]
     assert item["id"] == article.id
@@ -82,7 +82,7 @@ async def test_bulk_rescore_endpoint_requeues_and_rescores(
     await _run_pipeline_once(test_session)
 
     test_session.expire_all()
-    articles = test_client.get("/api/articles").json()
+    articles = test_client.get("/api/articles").json()["items"]
     assert articles[0]["scoring_state"] == "scored"
     assert articles[0]["interest_score"] == 7
 
@@ -138,7 +138,7 @@ async def test_rate_limited_pipeline_surfaces_in_status_and_requeues(
     test_session.expire_all()
     articles = test_client.get(
         "/api/articles", params={"scoring_state": "pending"}
-    ).json()
+    ).json()["items"]
     assert len(articles) == 1
 
 
@@ -167,12 +167,12 @@ async def test_blocked_articles_appear_only_in_blocked_view(
     test_session.expire_all()
 
     # Hidden from the default list
-    assert test_client.get("/api/articles").json() == []
+    assert test_client.get("/api/articles").json()["items"] == []
 
     # Inspectable in the blocked view
     blocked = test_client.get(
         "/api/articles", params={"scoring_state": "blocked"}
-    ).json()
+    ).json()["items"]
     assert len(blocked) == 1
     assert blocked[0]["id"] == article.id
 

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -8,6 +8,7 @@
         "@tanstack/react-query": "^5.101.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "dompurify": "^3.4.11",
         "lucide-react": "^1.23.0",
         "next": "16.2.10",
         "next-themes": "^0.4.6",
@@ -523,6 +524,8 @@
 
     "@types/statuses": ["@types/statuses@2.0.6", "", {}, "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="],
 
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
     "@types/validate-npm-package-name": ["@types/validate-npm-package-name@4.0.2", "", {}, "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.62.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.62.1", "@typescript-eslint/type-utils": "8.62.1", "@typescript-eslint/utils": "8.62.1", "@typescript-eslint/visitor-keys": "8.62.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.62.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA=="],
@@ -790,6 +793,8 @@
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
 
     "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
+
+    "dompurify": ["dompurify@3.4.11", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw=="],
 
     "dot-prop": ["dot-prop@6.0.1", "", { "dependencies": { "is-obj": "^2.0.0" } }, "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "@tanstack/react-query": "^5.101.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "dompurify": "^3.4.11",
     "lucide-react": "^1.23.0",
     "next": "16.2.10",
     "next-themes": "^0.4.6",

--- a/frontend/src/components/app-sidebar.test.tsx
+++ b/frontend/src/components/app-sidebar.test.tsx
@@ -110,11 +110,12 @@ describe("AppSidebar", () => {
     // Root feed rendered outside any folder.
     expect(await screen.findByText("xkcd")).toBeInTheDocument();
 
-    // Total unread (12 + 4) shown in the header.
+    // Global unread comes from the server counts endpoint (mockArticleCounts.unread),
+    // not a client-side sum of feed counts.
     await waitFor(() =>
       expect(
         screen.getByText("All articles").closest("button"),
-      ).toHaveTextContent("16"),
+      ).toHaveTextContent("32"),
     );
   });
 

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -2,6 +2,7 @@
 
 import { ChevronRight, Folder, Inbox, Rss } from "lucide-react";
 
+import { useArticleCounts } from "@/hooks/useArticleCounts";
 import { useFeeds } from "@/hooks/useFeeds";
 import { useFeedFolders } from "@/hooks/useFeedFolders";
 import { buildSidebarModel } from "@/lib/sidebar";
@@ -12,6 +13,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   Sidebar,
   SidebarContent,
@@ -52,6 +54,18 @@ function UnreadCount({ count }: { count: number }) {
   );
 }
 
+/**
+ * The global "All articles" badge. Server-computed total (`useArticleCounts`);
+ * shows a skeleton while loading rather than a client-side sum, and nothing when
+ * there are no unread articles.
+ */
+function GlobalUnreadCount({ count }: { count: number | null }) {
+  if (count === null) {
+    return <Skeleton className="ml-auto h-3 w-5 shrink-0 rounded" />;
+  }
+  return <UnreadCount count={count} />;
+}
+
 interface AppSidebarProps {
   selection: FeedSelection;
   onSelect: (selection: FeedSelection) => void;
@@ -60,6 +74,7 @@ interface AppSidebarProps {
 export function AppSidebar({ selection, onSelect }: AppSidebarProps) {
   const feedsQuery = useFeeds();
   const foldersQuery = useFeedFolders();
+  const countsQuery = useArticleCounts();
 
   const isLoading = feedsQuery.isPending || foldersQuery.isPending;
   const isError = feedsQuery.isError || foldersQuery.isError;
@@ -67,6 +82,7 @@ export function AppSidebar({ selection, onSelect }: AppSidebarProps) {
   const model = buildSidebarModel(
     feedsQuery.data ?? [],
     foldersQuery.data ?? [],
+    countsQuery.data?.unread ?? null,
   );
 
   return (
@@ -81,7 +97,7 @@ export function AppSidebar({ selection, onSelect }: AppSidebarProps) {
             >
               <Inbox className="size-4" />
               <span className="font-medium">All articles</span>
-              <UnreadCount count={model.totalUnread} />
+              <GlobalUnreadCount count={model.totalUnread} />
             </SidebarMenuButton>
           </SidebarMenuItem>
         </SidebarMenu>

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -56,10 +56,26 @@ function UnreadCount({ count }: { count: number }) {
 
 /**
  * The global "All articles" badge. Server-computed total (`useArticleCounts`);
- * shows a skeleton while loading rather than a client-side sum, and nothing when
- * there are no unread articles.
+ * shows a skeleton while loading rather than a client-side sum, a muted dash if
+ * the counts query fails, and nothing when there are no unread articles.
  */
-function GlobalUnreadCount({ count }: { count: number | null }) {
+function GlobalUnreadCount({
+  count,
+  isError,
+}: {
+  count: number | null;
+  isError: boolean;
+}) {
+  if (isError) {
+    return (
+      <span
+        className="ml-auto shrink-0 text-xs opacity-50"
+        title="Couldn't load unread count"
+      >
+        –
+      </span>
+    );
+  }
   if (count === null) {
     return <Skeleton className="ml-auto h-3 w-5 shrink-0 rounded" />;
   }
@@ -97,7 +113,10 @@ export function AppSidebar({ selection, onSelect }: AppSidebarProps) {
             >
               <Inbox className="size-4" />
               <span className="font-medium">All articles</span>
-              <GlobalUnreadCount count={model.totalUnread} />
+              <GlobalUnreadCount
+                count={model.totalUnread}
+                isError={countsQuery.isError}
+              />
             </SidebarMenuButton>
           </SidebarMenuItem>
         </SidebarMenu>

--- a/frontend/src/components/article-badges.tsx
+++ b/frontend/src/components/article-badges.tsx
@@ -1,0 +1,36 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * Small read-state / score / category tokens shared by the article list
+ * rows and the reader's overline so the two surfaces can never drift apart.
+ */
+
+/** Filled accent dot = unread, hollow dot = read (project visual rule). */
+export function ReadDot({ read }: { read: boolean }) {
+  return (
+    <span
+      className={cn(
+        "size-2 rounded-full",
+        read
+          ? "border-muted-foreground/50 border bg-transparent"
+          : "bg-primary",
+      )}
+    />
+  );
+}
+
+export function ScoreChip({ score }: { score: number }) {
+  return (
+    <span className="bg-secondary text-secondary-foreground rounded px-1.5 py-0.5 text-[11px]">
+      {score.toFixed(1)}
+    </span>
+  );
+}
+
+export function CategoryChip({ label }: { label: string }) {
+  return (
+    <span className="text-muted-foreground rounded border px-1.5 py-0.5 text-[11px]">
+      {label}
+    </span>
+  );
+}

--- a/frontend/src/components/article-list.test.tsx
+++ b/frontend/src/components/article-list.test.tsx
@@ -1,0 +1,104 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it, vi } from "vitest";
+import { ArticleList } from "@/components/article-list";
+import { mockArticles } from "@/test/mocks/handlers/articles";
+import { server } from "@/test/mocks/server";
+import {
+  createTestQueryClient,
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from "@/test/utils";
+
+/**
+ * Render ArticleList directly (no sidebar tree) with its own QueryClient so we
+ * keep the tree small and avoid the matchMedia stub the sidebar would need.
+ */
+function renderList() {
+  const queryClient = createTestQueryClient();
+  const onOpen = vi.fn();
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ArticleList selection={{ type: "all" }} onOpen={onOpen} />
+    </QueryClientProvider>,
+  );
+  return { queryClient, onOpen };
+}
+
+describe("ArticleList", () => {
+  it("renders article rows from the API grouped by date", async () => {
+    renderList();
+
+    // All 32 fixtures share published_at 2026-07-01, which is "Earlier".
+    expect(await screen.findByText("Article 2")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Earlier" }),
+    ).toBeInTheDocument();
+    // First page is 25 items — Article 25 is present, Article 26 is not yet.
+    expect(screen.getByText("Article 25")).toBeInTheDocument();
+    expect(screen.queryByText("Article 26")).not.toBeInTheDocument();
+  });
+
+  it("appends the next page when Load more is clicked", async () => {
+    const user = userEvent.setup();
+    renderList();
+
+    await screen.findByText("Article 2");
+    const loadMore = screen.getByRole("button", { name: "Load more" });
+    await user.click(loadMore);
+
+    // Page 2 brings in the remaining 7 fixtures (26–32).
+    await waitFor(() =>
+      expect(screen.getByText("Article 32")).toBeInTheDocument(),
+    );
+    // Page 1 rows are still mounted (appended, not replaced).
+    expect(screen.getByText("Article 2")).toBeInTheDocument();
+    // No more pages — the button is gone.
+    expect(
+      screen.queryByRole("button", { name: /load more/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("marks a row read via the dot toggle and dims the row", async () => {
+    const user = userEvent.setup();
+    let patchedRead: boolean | null = null;
+    server.use(
+      http.patch("/api/articles/:id", async ({ params, request }) => {
+        const body = (await request.json()) as { is_read: boolean };
+        patchedRead = body.is_read;
+        return HttpResponse.json({
+          ...mockArticles[0],
+          id: Number(params.id),
+          is_read: body.is_read,
+          summary: null,
+          content: null,
+        });
+      }),
+    );
+
+    renderList();
+
+    // All fixtures are unread — each row's dot button offers "Mark as read".
+    const markButtons = await screen.findAllByRole("button", {
+      name: "Mark as read",
+    });
+    const firstRow = markButtons[0].closest("article");
+    expect(firstRow).not.toHaveClass("opacity-60");
+
+    await user.click(markButtons[0]);
+
+    // The PATCH fired with is_read: true...
+    await waitFor(() => expect(patchedRead).toBe(true));
+    // ...and exactly one row now offers "Mark as unread" and is dimmed.
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Mark as unread" }),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByRole("button", { name: "Mark as unread" }).closest("article"),
+    ).toHaveClass("opacity-60");
+  });
+});

--- a/frontend/src/components/article-list.tsx
+++ b/frontend/src/components/article-list.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { Inbox } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useArticles } from "@/hooks/useArticles";
+import { useMarkRead } from "@/hooks/useMarkRead";
+import { cn, formatAge } from "@/lib/utils";
+import type { ArticleListItem, FeedSelection } from "@/lib/types";
+
+type GroupLabel = "Today" | "Yesterday" | "Earlier";
+
+const GROUP_ORDER: GroupLabel[] = ["Today", "Yesterday", "Earlier"];
+
+/** How many skeleton rows to show while the first page loads. */
+const SKELETON_ROW_COUNT = 6;
+
+function startOfDay(d: Date): number {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+}
+
+/** Bucket by published date. Null/invalid dates fall into "Earlier". */
+function groupFor(publishedAt: string | null): GroupLabel {
+  if (!publishedAt) return "Earlier";
+  const published = new Date(publishedAt);
+  if (Number.isNaN(published.getTime())) return "Earlier";
+  const today = startOfDay(new Date());
+  const day = startOfDay(published);
+  if (day >= today) return "Today";
+  if (day >= today - 24 * 60 * 60 * 1000) return "Yesterday";
+  return "Earlier";
+}
+
+function ReadDot({ read }: { read: boolean }) {
+  return (
+    <span
+      className={cn(
+        "size-2 rounded-full",
+        read
+          ? "border-muted-foreground/50 border bg-transparent"
+          : "bg-primary",
+      )}
+    />
+  );
+}
+
+function ScoreChip({ score }: { score: number }) {
+  return (
+    <span className="bg-secondary text-secondary-foreground rounded px-1.5 py-0.5 text-[11px]">
+      {score.toFixed(1)}
+    </span>
+  );
+}
+
+function CategoryChip({ label }: { label: string }) {
+  return (
+    <span className="text-muted-foreground rounded border px-1.5 py-0.5 text-[11px]">
+      {label}
+    </span>
+  );
+}
+
+function ArticleRow({
+  article,
+  isLast,
+  onOpen,
+  onToggleRead,
+}: {
+  article: ArticleListItem;
+  isLast: boolean;
+  onOpen: (article: ArticleListItem) => void;
+  onToggleRead: (article: ArticleListItem) => void;
+}) {
+  const read = article.is_read;
+  const categories = article.categories ?? [];
+  return (
+    <article
+      onClick={() => onOpen(article)}
+      className={cn(
+        "cursor-pointer px-4 py-4",
+        read && "opacity-60",
+        !isLast && "border-border/50 border-b",
+      )}
+    >
+      {/* Overline meta row — the dot is the read toggle */}
+      <div className="text-muted-foreground flex items-center gap-1.5 text-xs">
+        <button
+          type="button"
+          aria-label={read ? "Mark as unread" : "Mark as read"}
+          className="-m-3 flex size-10 shrink-0 items-center justify-center"
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleRead(article);
+          }}
+        >
+          <ReadDot read={read} />
+        </button>
+        <span className="truncate">
+          {article.feed_title} · {formatAge(article.published_at)}
+        </span>
+      </div>
+
+      <h3
+        className={cn(
+          "mt-1 font-serif text-xl leading-tight",
+          !read && "font-semibold",
+        )}
+      >
+        {article.title}
+      </h3>
+
+      {(article.composite_score !== null || categories.length > 0) && (
+        <div className="mt-2 flex flex-wrap items-center gap-1.5">
+          {article.composite_score !== null && (
+            <ScoreChip score={article.composite_score} />
+          )}
+          {categories.map((category) => (
+            <CategoryChip key={category.id} label={category.display_name} />
+          ))}
+        </div>
+      )}
+    </article>
+  );
+}
+
+interface ArticleListProps {
+  selection: FeedSelection;
+  onOpen: (article: ArticleListItem) => void;
+}
+
+export function ArticleList({ selection, onOpen }: ArticleListProps) {
+  const {
+    articles,
+    isPending,
+    isError,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useArticles(selection);
+  const markRead = useMarkRead();
+
+  const toggleRead = (article: ArticleListItem) => {
+    markRead.mutate({ id: article.id, isRead: !article.is_read });
+  };
+
+  if (isPending) {
+    return (
+      <div className="h-full overflow-y-auto">
+        <div className="space-y-6 p-4">
+          {Array.from({ length: SKELETON_ROW_COUNT }, (_, i) => (
+            <div key={i} className="space-y-2">
+              <Skeleton className="h-3 w-32" />
+              <Skeleton className="h-6 w-[85%]" />
+              <Skeleton className="h-4 w-24" />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="flex h-full items-center justify-center p-8">
+        <p className="text-muted-foreground text-sm">
+          Couldn&apos;t load articles. Retrying…
+        </p>
+      </div>
+    );
+  }
+
+  if (articles.length === 0) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 p-8 text-center">
+        <Inbox className="text-muted-foreground size-8" />
+        <p className="font-medium">No articles</p>
+        <p className="text-muted-foreground text-sm">
+          Articles for this view will appear here.
+        </p>
+      </div>
+    );
+  }
+
+  const groups = GROUP_ORDER.map((label) => ({
+    label,
+    items: articles.filter((a) => groupFor(a.published_at) === label),
+  })).filter((g) => g.items.length > 0);
+
+  return (
+    <div className="h-full overflow-y-auto">
+      {groups.map((group) => (
+        <section key={group.label}>
+          <h2 className="bg-background text-muted-foreground sticky top-0 px-4 pt-4 pb-1 text-xs font-medium tracking-wide uppercase">
+            {group.label}
+          </h2>
+          {group.items.map((article, i) => (
+            <ArticleRow
+              key={article.id}
+              article={article}
+              isLast={i === group.items.length - 1}
+              onOpen={onOpen}
+              onToggleRead={toggleRead}
+            />
+          ))}
+        </section>
+      ))}
+
+      {hasNextPage && (
+        <div className="p-4">
+          <Button
+            variant="ghost"
+            className="w-full"
+            disabled={isFetchingNextPage}
+            onClick={() => fetchNextPage()}
+          >
+            {isFetchingNextPage ? "Loading…" : "Load more"}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/article-list.tsx
+++ b/frontend/src/components/article-list.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { Inbox } from "lucide-react";
+import { useMemo } from "react";
 
+import { CategoryChip, ReadDot, ScoreChip } from "@/components/article-badges";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useArticles } from "@/hooks/useArticles";
 import { useMarkRead } from "@/hooks/useMarkRead";
-import { cn, formatAge } from "@/lib/utils";
+import { cn, formatAge, parseServerDate } from "@/lib/utils";
 import type { ArticleListItem, FeedSelection } from "@/lib/types";
 
 type GroupLabel = "Today" | "Yesterday" | "Earlier";
@@ -23,42 +25,20 @@ function startOfDay(d: Date): number {
 /** Bucket by published date. Null/invalid dates fall into "Earlier". */
 function groupFor(publishedAt: string | null): GroupLabel {
   if (!publishedAt) return "Earlier";
-  const published = new Date(publishedAt);
+  const published = parseServerDate(publishedAt);
   if (Number.isNaN(published.getTime())) return "Earlier";
-  const today = startOfDay(new Date());
+  const now = new Date();
+  const todayStart = startOfDay(now);
+  // Date-field arithmetic, not a fixed 24h offset — DST days are 23/25h long.
+  const yesterdayStart = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate() - 1,
+  ).getTime();
   const day = startOfDay(published);
-  if (day >= today) return "Today";
-  if (day >= today - 24 * 60 * 60 * 1000) return "Yesterday";
+  if (day >= todayStart) return "Today";
+  if (day >= yesterdayStart) return "Yesterday";
   return "Earlier";
-}
-
-function ReadDot({ read }: { read: boolean }) {
-  return (
-    <span
-      className={cn(
-        "size-2 rounded-full",
-        read
-          ? "border-muted-foreground/50 border bg-transparent"
-          : "bg-primary",
-      )}
-    />
-  );
-}
-
-function ScoreChip({ score }: { score: number }) {
-  return (
-    <span className="bg-secondary text-secondary-foreground rounded px-1.5 py-0.5 text-[11px]">
-      {score.toFixed(1)}
-    </span>
-  );
-}
-
-function CategoryChip({ label }: { label: string }) {
-  return (
-    <span className="text-muted-foreground rounded border px-1.5 py-0.5 text-[11px]">
-      {label}
-    </span>
-  );
 }
 
 function ArticleRow({
@@ -144,6 +124,17 @@ export function ArticleList({ selection, onOpen }: ArticleListProps) {
     markRead.mutate({ id: article.id, isRead: !article.is_read });
   };
 
+  // Recompute buckets only when the article set changes — not on every
+  // mark-read re-render of a long loaded list.
+  const groups = useMemo(
+    () =>
+      GROUP_ORDER.map((label) => ({
+        label,
+        items: articles.filter((a) => groupFor(a.published_at) === label),
+      })).filter((g) => g.items.length > 0),
+    [articles],
+  );
+
   if (isPending) {
     return (
       <div className="h-full overflow-y-auto">
@@ -181,11 +172,6 @@ export function ArticleList({ selection, onOpen }: ArticleListProps) {
       </div>
     );
   }
-
-  const groups = GROUP_ORDER.map((label) => ({
-    label,
-    items: articles.filter((a) => groupFor(a.published_at) === label),
-  })).filter((g) => g.items.length > 0);
 
   return (
     <div className="h-full overflow-y-auto">

--- a/frontend/src/components/article-reader.test.tsx
+++ b/frontend/src/components/article-reader.test.tsx
@@ -29,7 +29,7 @@ function listItem(overrides: Partial<ArticleListItem> = {}): ArticleListItem {
         id: 5,
         display_name: "Machine Learning",
         slug: "ml",
-        effective_weight: 1,
+        effective_weight: "normal",
         parent_display_name: null,
       },
     ],

--- a/frontend/src/components/article-reader.test.tsx
+++ b/frontend/src/components/article-reader.test.tsx
@@ -1,0 +1,152 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it, vi } from "vitest";
+import { ArticleReader } from "@/components/article-reader";
+import { mockArticleDetail } from "@/test/mocks/handlers/articles";
+import { server } from "@/test/mocks/server";
+import type { ArticleListItem } from "@/lib/types";
+import {
+  createTestQueryClient,
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from "@/test/utils";
+
+/** A list item carrying the meta/score fields the reader renders from props. */
+function listItem(overrides: Partial<ArticleListItem> = {}): ArticleListItem {
+  return {
+    id: 1,
+    feed_id: 2,
+    feed_title: "Feed B",
+    title: "Article 1",
+    url: "https://example.com/articles/1",
+    author: null,
+    published_at: "2026-07-01T00:00:00",
+    is_read: false,
+    categories: [
+      {
+        id: 5,
+        display_name: "Machine Learning",
+        slug: "ml",
+        effective_weight: 1,
+        parent_display_name: null,
+      },
+    ],
+    interest_score: null,
+    quality_score: 8,
+    composite_score: 17.4,
+    score_reasoning: "Directly relevant to your interests.",
+    summary_preview: null,
+    scoring_state: "scored",
+    scored_at: null,
+    re_evaluating: false,
+    ...overrides,
+  };
+}
+
+function renderReader(
+  article: ArticleListItem,
+  { dwellMs }: { dwellMs?: number } = {},
+) {
+  const queryClient = createTestQueryClient();
+  const onClose = vi.fn();
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ArticleReader article={article} onClose={onClose} dwellMs={dwellMs} />
+    </QueryClientProvider>,
+  );
+  return { queryClient, onClose };
+}
+
+describe("ArticleReader", () => {
+  it("renders title, meta, scores, reasoning, and the sanitized body", async () => {
+    renderReader(listItem());
+
+    expect(
+      screen.getByRole("heading", { name: "Article 1" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Feed B/)).toBeInTheDocument();
+    expect(screen.getByText("relevance 17.4")).toBeInTheDocument();
+    expect(screen.getByText("quality 8/10")).toBeInTheDocument();
+    expect(
+      screen.getByText("Directly relevant to your interests."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Machine Learning")).toBeInTheDocument();
+
+    // Body arrives from the detail query (content = "<p>Full article content</p>").
+    expect(await screen.findByText("Full article content")).toBeInTheDocument();
+  });
+
+  it("strips dangerous markup from the body before rendering", async () => {
+    server.use(
+      http.get("/api/articles/:id", ({ params }) =>
+        HttpResponse.json({
+          ...mockArticleDetail,
+          id: Number(params.id),
+          content: '<p>Safe text</p><img src=x onerror="alert(1)">',
+        }),
+      ),
+    );
+
+    renderReader(listItem());
+
+    expect(await screen.findByText("Safe text")).toBeInTheDocument();
+    // DOMPurify keeps the img but drops the onerror handler.
+    const img = document.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute("onerror")).toBeNull();
+  });
+
+  it("calls onClose on the Done button and on Escape", async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderReader(listItem());
+
+    await user.click(screen.getByRole("button", { name: /done/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    await user.keyboard("{Escape}");
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it("auto-marks the article read after the dwell window", async () => {
+    let patchedRead: boolean | null = null;
+    server.use(
+      http.patch("/api/articles/:id", async ({ params, request }) => {
+        const body = (await request.json()) as { is_read: boolean };
+        patchedRead = body.is_read;
+        return HttpResponse.json({
+          ...mockArticleDetail,
+          id: Number(params.id),
+          is_read: body.is_read,
+        });
+      }),
+    );
+
+    // Short real dwell to stay reliable alongside MSW/TanStack async.
+    renderReader(listItem({ is_read: false }), { dwellMs: 20 });
+
+    await waitFor(() => expect(patchedRead).toBe(true));
+  });
+
+  it("does not auto-mark an already-read article", async () => {
+    let patched = false;
+    server.use(
+      http.patch("/api/articles/:id", async ({ params, request }) => {
+        patched = true;
+        const body = (await request.json()) as { is_read: boolean };
+        return HttpResponse.json({
+          ...mockArticleDetail,
+          id: Number(params.id),
+          is_read: body.is_read,
+        });
+      }),
+    );
+
+    renderReader(listItem({ is_read: true }), { dwellMs: 20 });
+
+    // Wait past the dwell window; no PATCH should have fired.
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(patched).toBe(false);
+  });
+});

--- a/frontend/src/components/article-reader.tsx
+++ b/frontend/src/components/article-reader.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import DOMPurify from "dompurify";
+import { Check } from "lucide-react";
+import { useEffect, useMemo } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useArticle } from "@/hooks/useArticle";
+import { useMarkRead } from "@/hooks/useMarkRead";
+import { cn, formatAge } from "@/lib/utils";
+import type { ArticleListItem } from "@/lib/types";
+
+/** Dwell threshold before auto-marking an opened article read — issue #94 decision. */
+const MARK_READ_DWELL_MS = 3000;
+
+function ReadDot({ read }: { read: boolean }) {
+  return (
+    <span
+      className={cn(
+        "size-2 rounded-full",
+        read
+          ? "border-muted-foreground/50 border bg-transparent"
+          : "bg-primary",
+      )}
+    />
+  );
+}
+
+function CategoryChip({ label }: { label: string }) {
+  return (
+    <span className="text-muted-foreground rounded border px-1.5 py-0.5 text-[11px]">
+      {label}
+    </span>
+  );
+}
+
+interface ArticleReaderProps {
+  /** The list item that was opened — supplies feed/meta/score fields immediately. */
+  article: ArticleListItem;
+  onClose: () => void;
+  /** Overridable only for tests; production uses the #94-decided threshold. */
+  dwellMs?: number;
+}
+
+export function ArticleReader({
+  article,
+  onClose,
+  dwellMs = MARK_READ_DWELL_MS,
+}: ArticleReaderProps) {
+  const detailQuery = useArticle(article.id);
+  const markRead = useMarkRead();
+
+  // Live read status tracks the cached detail (the mark-read mutation flips it),
+  // falling back to the list item until the detail query resolves.
+  const isRead = detailQuery.data?.is_read ?? article.is_read;
+
+  const categories = article.categories ?? [];
+  const rawBody = detailQuery.data
+    ? (detailQuery.data.content ?? detailQuery.data.summary)
+    : undefined;
+  const bodyHtml = useMemo(
+    () => (rawBody != null ? DOMPurify.sanitize(rawBody) : null),
+    [rawBody],
+  );
+
+  // Esc closes the reader (listener mounted only while the reader is open).
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  // Dwell auto-mark (#94): mark read `dwellMs` after open if it was unread when
+  // opened. Never auto-marks unread. The opened article is frozen in shell state
+  // for the reader's lifetime, so `is_read`/`id` here reflect open-time state; the
+  // timer re-arms per article. `mutate` (not the mutation object) is a stable ref.
+  const markMutate = markRead.mutate;
+  const articleId = article.id;
+  const wasUnreadAtOpen = !article.is_read;
+  useEffect(() => {
+    if (!wasUnreadAtOpen) return;
+    const timer = setTimeout(() => {
+      markMutate({ id: articleId, isRead: true });
+    }, dwellMs);
+    return () => clearTimeout(timer);
+  }, [articleId, wasUnreadAtOpen, dwellMs, markMutate]);
+
+  return (
+    <div className="bg-background animate-in fade-in fixed inset-0 z-40 flex flex-col duration-200">
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <div className="px-5 pt-10 pb-24">
+          <div className="mx-auto max-w-[68ch]">
+            {/* Overline: live read status + category chips, above the headline */}
+            <div className="mb-3 flex flex-wrap items-center gap-1.5">
+              <span className="text-muted-foreground mr-1 flex items-center gap-1.5 text-xs">
+                <ReadDot read={isRead} />
+                {isRead ? "Read" : "Unread"}
+              </span>
+              {categories.map((category) => (
+                <CategoryChip key={category.id} label={category.display_name} />
+              ))}
+            </div>
+
+            <h1 className="font-serif text-3xl leading-tight font-bold">
+              {article.title}
+            </h1>
+            <p className="text-muted-foreground mt-2 text-sm">
+              {article.feed_title} · {formatAge(article.published_at)}
+            </p>
+
+            <div className="mt-4 space-y-3">
+              {(article.composite_score !== null ||
+                article.quality_score !== null) && (
+                <div className="text-muted-foreground flex flex-wrap items-center gap-x-4 gap-y-1 text-xs">
+                  {article.composite_score !== null && (
+                    <span>relevance {article.composite_score.toFixed(1)}</span>
+                  )}
+                  {article.quality_score !== null && (
+                    <span>quality {article.quality_score}/10</span>
+                  )}
+                </div>
+              )}
+              {article.score_reasoning !== null && (
+                <blockquote className="text-muted-foreground border-l-2 pl-3 font-serif text-sm italic">
+                  {article.score_reasoning}
+                </blockquote>
+              )}
+            </div>
+          </div>
+
+          {bodyHtml === null ? (
+            <div className="mx-auto mt-8 max-w-[68ch] space-y-3">
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-[92%]" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-[85%]" />
+              <Skeleton className="h-4 w-[70%]" />
+              <Skeleton className="mt-6 h-4 w-full" />
+              <Skeleton className="h-4 w-[88%]" />
+              <Skeleton className="h-4 w-[60%]" />
+            </div>
+          ) : (
+            <div
+              className="[&_blockquote]:text-muted-foreground mx-auto mt-6 max-w-[68ch] font-serif text-[17px] leading-[1.7] [&_a]:underline [&_blockquote]:border-l-2 [&_blockquote]:pl-4 [&_blockquote]:italic [&_h2]:mt-8 [&_h2]:mb-2 [&_h2]:text-xl [&_h2]:font-semibold [&_img]:max-w-full [&_li]:mt-1 [&_p]:mt-4 [&_pre]:overflow-x-auto [&_ul]:mt-4 [&_ul]:list-disc [&_ul]:pl-5"
+              dangerouslySetInnerHTML={{ __html: bodyHtml }}
+            />
+          )}
+        </div>
+      </div>
+      <Button
+        onClick={onClose}
+        className="fixed bottom-6 left-1/2 z-50 -translate-x-1/2 rounded-full shadow-lg"
+      >
+        <Check />
+        Done
+      </Button>
+    </div>
+  );
+}
+
+export { MARK_READ_DWELL_MS };

--- a/frontend/src/components/article-reader.tsx
+++ b/frontend/src/components/article-reader.tsx
@@ -4,36 +4,16 @@ import DOMPurify from "dompurify";
 import { Check } from "lucide-react";
 import { useEffect, useMemo } from "react";
 
+import { CategoryChip, ReadDot } from "@/components/article-badges";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useArticle } from "@/hooks/useArticle";
 import { useMarkRead } from "@/hooks/useMarkRead";
-import { cn, formatAge } from "@/lib/utils";
+import { formatAge } from "@/lib/utils";
 import type { ArticleListItem } from "@/lib/types";
 
 /** Dwell threshold before auto-marking an opened article read — issue #94 decision. */
 const MARK_READ_DWELL_MS = 3000;
-
-function ReadDot({ read }: { read: boolean }) {
-  return (
-    <span
-      className={cn(
-        "size-2 rounded-full",
-        read
-          ? "border-muted-foreground/50 border bg-transparent"
-          : "bg-primary",
-      )}
-    />
-  );
-}
-
-function CategoryChip({ label }: { label: string }) {
-  return (
-    <span className="text-muted-foreground rounded border px-1.5 py-0.5 text-[11px]">
-      {label}
-    </span>
-  );
-}
 
 interface ArticleReaderProps {
   /** The list item that was opened — supplies feed/meta/score fields immediately. */
@@ -73,20 +53,22 @@ export function ArticleReader({
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [onClose]);
 
-  // Dwell auto-mark (#94): mark read `dwellMs` after open if it was unread when
-  // opened. Never auto-marks unread. The opened article is frozen in shell state
-  // for the reader's lifetime, so `is_read`/`id` here reflect open-time state; the
-  // timer re-arms per article. `mutate` (not the mutation object) is a stable ref.
+  // Dwell auto-mark (#94): mark read `dwellMs` after the content is readable,
+  // if the article was unread when opened. Never auto-marks unread, and never
+  // marks an article whose content failed to load. The opened article is frozen
+  // in shell state for the reader's lifetime, so `is_read`/`id` here reflect
+  // open-time state; `mutate` (not the mutation object) is a stable ref.
   const markMutate = markRead.mutate;
   const articleId = article.id;
   const wasUnreadAtOpen = !article.is_read;
+  const contentLoaded = detailQuery.isSuccess;
   useEffect(() => {
-    if (!wasUnreadAtOpen) return;
+    if (!wasUnreadAtOpen || !contentLoaded) return;
     const timer = setTimeout(() => {
       markMutate({ id: articleId, isRead: true });
     }, dwellMs);
     return () => clearTimeout(timer);
-  }, [articleId, wasUnreadAtOpen, dwellMs, markMutate]);
+  }, [articleId, wasUnreadAtOpen, contentLoaded, dwellMs, markMutate]);
 
   return (
     <div className="bg-background animate-in fade-in fixed inset-0 z-40 flex flex-col duration-200">
@@ -131,7 +113,19 @@ export function ArticleReader({
             </div>
           </div>
 
-          {bodyHtml === null ? (
+          {detailQuery.isError ? (
+            <p className="text-muted-foreground mx-auto mt-8 max-w-[68ch] text-sm">
+              Couldn&apos;t load this article.{" "}
+              <a
+                href={article.url}
+                target="_blank"
+                rel="noreferrer"
+                className="underline"
+              >
+                Open the original
+              </a>
+            </p>
+          ) : detailQuery.isPending ? (
             <div className="mx-auto mt-8 max-w-[68ch] space-y-3">
               <Skeleton className="h-4 w-full" />
               <Skeleton className="h-4 w-[92%]" />
@@ -142,6 +136,18 @@ export function ArticleReader({
               <Skeleton className="h-4 w-[88%]" />
               <Skeleton className="h-4 w-[60%]" />
             </div>
+          ) : bodyHtml === null ? (
+            <p className="text-muted-foreground mx-auto mt-8 max-w-[68ch] text-sm">
+              This article has no content.{" "}
+              <a
+                href={article.url}
+                target="_blank"
+                rel="noreferrer"
+                className="underline"
+              >
+                Open the original
+              </a>
+            </p>
           ) : (
             <div
               className="[&_blockquote]:text-muted-foreground mx-auto mt-6 max-w-[68ch] font-serif text-[17px] leading-[1.7] [&_a]:underline [&_blockquote]:border-l-2 [&_blockquote]:pl-4 [&_blockquote]:italic [&_h2]:mt-8 [&_h2]:mb-2 [&_h2]:text-xl [&_h2]:font-semibold [&_img]:max-w-full [&_li]:mt-1 [&_p]:mt-4 [&_pre]:overflow-x-auto [&_ul]:mt-4 [&_ul]:list-disc [&_ul]:pl-5"
@@ -160,5 +166,3 @@ export function ArticleReader({
     </div>
   );
 }
-
-export { MARK_READ_DWELL_MS };

--- a/frontend/src/components/home-shell.tsx
+++ b/frontend/src/components/home-shell.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useEffect } from "react";
-import { Inbox } from "lucide-react";
+import { useEffect, useState } from "react";
 
 import { AppSidebar } from "@/components/app-sidebar";
+import { ArticleList } from "@/components/article-list";
+import { ArticleReader } from "@/components/article-reader";
 import {
   SidebarInset,
   SidebarProvider,
@@ -17,7 +18,11 @@ import {
   resolveSelection,
   selectionName,
 } from "@/lib/selection";
-import { ALL_ARTICLES_SELECTION, type FeedSelection } from "@/lib/types";
+import {
+  ALL_ARTICLES_SELECTION,
+  type ArticleListItem,
+  type FeedSelection,
+} from "@/lib/types";
 
 const SELECTION_STORAGE_KEY = "rss-reader:selection";
 
@@ -32,6 +37,9 @@ export function HomeShell() {
   const foldersQuery = useFeedFolders();
   const feeds = feedsQuery.data ?? [];
   const folders = foldersQuery.data ?? [];
+
+  // The open article is shell-level UI state (URL state is a later milestone).
+  const [openArticle, setOpenArticle] = useState<ArticleListItem | null>(null);
 
   // Fall back to All articles if the stored selection points at a
   // feed/folder that no longer exists (validated once data has loaded).
@@ -53,19 +61,20 @@ export function HomeShell() {
   return (
     <SidebarProvider>
       <AppSidebar selection={selection} onSelect={setStored} />
-      <SidebarInset>
-        <header className="flex h-14 items-center gap-2 border-b px-4">
+      {/* The h-svh/min-h-0 constrained-height chain is the #93 shell decision. */}
+      <SidebarInset className="h-svh overflow-hidden">
+        <header className="flex h-14 shrink-0 items-center gap-2 border-b px-4">
           <SidebarTrigger />
           <h1 className="text-sm font-medium">{header}</h1>
         </header>
-        <main className="flex flex-1 flex-col items-center justify-center gap-3 p-8 text-center">
-          <Inbox className="text-muted-foreground size-10" />
-          <div className="space-y-1">
-            <p className="text-sm font-medium">No articles</p>
-            <p className="text-muted-foreground text-sm">
-              Articles for this view will appear here.
-            </p>
-          </div>
+        <main className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          <ArticleList selection={selection} onOpen={setOpenArticle} />
+          {openArticle !== null && (
+            <ArticleReader
+              article={openArticle}
+              onClose={() => setOpenArticle(null)}
+            />
+          )}
         </main>
       </SidebarInset>
     </SidebarProvider>

--- a/frontend/src/hooks/useArticle.test.tsx
+++ b/frontend/src/hooks/useArticle.test.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { useArticle } from "@/hooks/useArticle";
+import { createWrapper, renderHook, waitFor } from "@/test/utils";
+import { mockArticleDetail } from "@/test/mocks/handlers/articles";
+
+describe("useArticle", () => {
+  it("returns the article detail from the API", async () => {
+    const { result } = renderHook(() => useArticle(1), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockArticleDetail);
+  });
+
+  it("does not fetch when id is null", () => {
+    const { result } = renderHook(() => useArticle(null), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.fetchStatus).toBe("idle");
+  });
+});

--- a/frontend/src/hooks/useArticle.ts
+++ b/frontend/src/hooks/useArticle.ts
@@ -1,0 +1,13 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { fetchArticle } from "@/lib/api";
+import { queryKeys } from "@/lib/queryKeys";
+
+export function useArticle(id: number | null) {
+  return useQuery({
+    queryKey: queryKeys.articles.detail(id ?? -1),
+    queryFn: () => fetchArticle(id as number),
+    enabled: id !== null,
+  });
+}

--- a/frontend/src/hooks/useArticleCounts.test.tsx
+++ b/frontend/src/hooks/useArticleCounts.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { useArticleCounts } from "@/hooks/useArticleCounts";
+import { createWrapper, renderHook, waitFor } from "@/test/utils";
+import { mockArticleCounts } from "@/test/mocks/handlers/articles";
+
+describe("useArticleCounts", () => {
+  it("returns the four counts from the API", async () => {
+    const { result } = renderHook(() => useArticleCounts(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockArticleCounts);
+  });
+});

--- a/frontend/src/hooks/useArticleCounts.ts
+++ b/frontend/src/hooks/useArticleCounts.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { fetchArticleCounts } from "@/lib/api";
+import { FEED_STATE_POLL_INTERVAL } from "@/lib/constants";
+import { queryKeys } from "@/lib/queryKeys";
+
+export function useArticleCounts() {
+  return useQuery({
+    queryKey: queryKeys.articles.counts,
+    queryFn: fetchArticleCounts,
+    refetchInterval: FEED_STATE_POLL_INTERVAL,
+  });
+}

--- a/frontend/src/hooks/useArticles.test.tsx
+++ b/frontend/src/hooks/useArticles.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { useArticles } from "@/hooks/useArticles";
+import { createWrapper, renderHook, waitFor } from "@/test/utils";
+import { mockArticles } from "@/test/mocks/handlers/articles";
+
+describe("useArticles", () => {
+  it("loads the first page and reports hasNextPage", async () => {
+    const { result } = renderHook(() => useArticles({ type: "all" }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.articles).toHaveLength(25);
+    expect(result.current.articles).toEqual(mockArticles.slice(0, 25));
+    expect(result.current.hasNextPage).toBe(true);
+  });
+
+  it("appends the next page on fetchNextPage and reports no more pages at the end", async () => {
+    const { result } = renderHook(() => useArticles({ type: "all" }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    result.current.fetchNextPage();
+
+    await waitFor(() => expect(result.current.articles).toHaveLength(32));
+    expect(result.current.articles).toEqual(mockArticles);
+    expect(result.current.hasNextPage).toBe(false);
+  });
+
+  it("filters by feed_id when the selection targets a feed", async () => {
+    const { result } = renderHook(() => useArticles({ type: "feed", id: 1 }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(
+      result.current.articles.every((article) => article.feed_id === 1),
+    ).toBe(true);
+    expect(result.current.hasNextPage).toBe(false);
+  });
+});

--- a/frontend/src/hooks/useArticles.test.tsx
+++ b/frontend/src/hooks/useArticles.test.tsx
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { useArticles } from "@/hooks/useArticles";
+import { useMarkRead } from "@/hooks/useMarkRead";
 import { createWrapper, renderHook, waitFor } from "@/test/utils";
 import { mockArticles } from "@/test/mocks/handlers/articles";
+import { server } from "@/test/mocks/server";
 
 describe("useArticles", () => {
   it("loads the first page and reports hasNextPage", async () => {
@@ -27,6 +29,37 @@ describe("useArticles", () => {
     await waitFor(() => expect(result.current.articles).toHaveLength(32));
     expect(result.current.articles).toEqual(mockArticles);
     expect(result.current.hasNextPage).toBe(false);
+  });
+
+  it("computes the next offset from cached unread items so marked-read rows don't shift the page window", async () => {
+    // Regression: the server query is unread-only, so items marked read leave
+    // the server's result set while staying in the cache. skip must count
+    // cached UNREAD items (24 after one mark-read), not all cached items (25).
+    const skips: string[] = [];
+    const onRequest = ({ request }: { request: Request }) => {
+      const url = new URL(request.url);
+      if (url.pathname === "/api/articles") {
+        skips.push(url.searchParams.get("skip") ?? "0");
+      }
+    };
+    server.events.on("request:start", onRequest);
+
+    try {
+      const { result } = renderHook(
+        () => ({ list: useArticles({ type: "all" }), mark: useMarkRead() }),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => expect(result.current.list.isSuccess).toBe(true));
+
+      result.current.mark.mutate({ id: mockArticles[0].id, isRead: true });
+      await waitFor(() => expect(result.current.mark.isSuccess).toBe(true));
+
+      result.current.list.fetchNextPage();
+      await waitFor(() => expect(skips).toContain("24"));
+      expect(skips).not.toContain("25");
+    } finally {
+      server.events.removeListener("request:start", onRequest);
+    }
   });
 
   it("filters by feed_id when the selection targets a feed", async () => {

--- a/frontend/src/hooks/useArticles.ts
+++ b/frontend/src/hooks/useArticles.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { fetchArticles } from "@/lib/api";
+import { queryKeys } from "@/lib/queryKeys";
+import type { FeedSelection } from "@/lib/types";
+
+const ARTICLES_PAGE_SIZE = 25;
+
+export function useArticles(selection: FeedSelection) {
+  const query = useInfiniteQuery({
+    queryKey: queryKeys.articles.list(selection),
+    queryFn: ({ pageParam }) =>
+      fetchArticles(selection, pageParam, ARTICLES_PAGE_SIZE),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) => {
+      if (!lastPage.has_more) return undefined;
+      return allPages.reduce((sum, page) => sum + page.items.length, 0);
+    },
+  });
+
+  const articles = useMemo(
+    () => query.data?.pages.flatMap((page) => page.items) ?? [],
+    [query.data],
+  );
+
+  return { ...query, articles };
+}

--- a/frontend/src/hooks/useArticles.ts
+++ b/frontend/src/hooks/useArticles.ts
@@ -16,7 +16,15 @@ export function useArticles(selection: FeedSelection) {
     initialPageParam: 0,
     getNextPageParam: (lastPage, allPages) => {
       if (!lastPage.has_more) return undefined;
-      return allPages.reduce((sum, page) => sum + page.items.length, 0);
+      // The server query is unread-only and re-evaluated per request: items we
+      // mark read leave the server's result set but stay in our cache (rows dim
+      // in place), so the next offset is the number of cached items still
+      // unread — not the raw cache length, which would overshoot and skip
+      // unread articles that shifted down.
+      return allPages.reduce(
+        (sum, page) => sum + page.items.filter((item) => !item.is_read).length,
+        0,
+      );
     },
   });
 

--- a/frontend/src/hooks/useMarkRead.test.tsx
+++ b/frontend/src/hooks/useMarkRead.test.tsx
@@ -1,0 +1,109 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it, vi } from "vitest";
+import { useArticle } from "@/hooks/useArticle";
+import { useArticles } from "@/hooks/useArticles";
+import { useMarkRead } from "@/hooks/useMarkRead";
+import { queryKeys } from "@/lib/queryKeys";
+import { createTestQueryClient, renderHook, waitFor } from "@/test/utils";
+import { mockArticles } from "@/test/mocks/handlers/articles";
+import { server } from "@/test/mocks/server";
+
+function wrapperWithClient(
+  queryClient: ReturnType<typeof createTestQueryClient>,
+) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe("useMarkRead", () => {
+  it("PATCHes the article and flips is_read in the cached list without a refetch", async () => {
+    const queryClient = createTestQueryClient();
+    const wrapper = wrapperWithClient(queryClient);
+
+    const { result: listResult } = renderHook(
+      () => useArticles({ type: "all" }),
+      { wrapper },
+    );
+    await waitFor(() => expect(listResult.current.isSuccess).toBe(true));
+
+    let fetchCount = 0;
+    server.use(
+      http.get("/api/articles", () => {
+        fetchCount += 1;
+        return HttpResponse.json({
+          items: mockArticles.slice(0, 25),
+          has_more: true,
+        });
+      }),
+    );
+
+    const { result: mutationResult } = renderHook(() => useMarkRead(), {
+      wrapper,
+    });
+
+    mutationResult.current.mutate({ id: 1, isRead: true });
+
+    await waitFor(() => expect(mutationResult.current.isSuccess).toBe(true));
+
+    // Assert against the cache directly (list pages), the source of truth the
+    // component reads from — sidesteps renderHook's effect-timing lag on
+    // externally-triggered cache writes and stays faithful to "no refetch".
+    const cached = queryClient.getQueryData<{
+      pages: { items: { id: number; is_read: boolean }[] }[];
+    }>(queryKeys.articles.list({ type: "all" }));
+    const items = cached?.pages.flatMap((page) => page.items) ?? [];
+    const updated = items.find((a) => a.id === 1);
+    expect(updated?.is_read).toBe(true);
+    // The row must remain in the list (dim in place), not vanish.
+    expect(items).toHaveLength(25);
+    expect(fetchCount).toBe(0);
+  });
+
+  it("updates the cached detail when present", async () => {
+    const queryClient = createTestQueryClient();
+    const wrapper = wrapperWithClient(queryClient);
+
+    const { result: detailResult } = renderHook(() => useArticle(1), {
+      wrapper,
+    });
+    await waitFor(() => expect(detailResult.current.isSuccess).toBe(true));
+
+    const { result: mutationResult } = renderHook(() => useMarkRead(), {
+      wrapper,
+    });
+
+    mutationResult.current.mutate({ id: 1, isRead: true });
+
+    await waitFor(() => expect(mutationResult.current.isSuccess).toBe(true));
+
+    const cached = queryClient.getQueryData<{ is_read: boolean }>(
+      queryKeys.articles.detail(1),
+    );
+    expect(cached?.is_read).toBe(true);
+  });
+
+  it("invalidates feeds, feed folders, and counts queries on success", async () => {
+    const queryClient = createTestQueryClient();
+    const wrapper = wrapperWithClient(queryClient);
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result: mutationResult } = renderHook(() => useMarkRead(), {
+      wrapper,
+    });
+
+    mutationResult.current.mutate({ id: 1, isRead: true });
+
+    await waitFor(() => expect(mutationResult.current.isSuccess).toBe(true));
+
+    const invalidatedKeys = invalidateSpy.mock.calls.map(
+      (call) => call[0]?.queryKey,
+    );
+    expect(invalidatedKeys).toContainEqual(queryKeys.feeds.all);
+    expect(invalidatedKeys).toContainEqual(queryKeys.feedFolders.all);
+    expect(invalidatedKeys).toContainEqual(queryKeys.articles.counts);
+  });
+});

--- a/frontend/src/hooks/useMarkRead.ts
+++ b/frontend/src/hooks/useMarkRead.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import {
+  useMutation,
+  useQueryClient,
+  type InfiniteData,
+} from "@tanstack/react-query";
+import { updateArticleRead } from "@/lib/api";
+import { queryKeys } from "@/lib/queryKeys";
+import type { Article, ArticleListResponse } from "@/lib/types";
+
+export function useMarkRead() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, isRead }: { id: number; isRead: boolean }) =>
+      updateArticleRead(id, isRead),
+    onSuccess: (updated, { id }) => {
+      // Surgically flip is_read in every cached articles list page — rows dim
+      // in place rather than vanish, which is the deliberate UX behavior.
+      queryClient.setQueriesData<InfiniteData<ArticleListResponse>>(
+        { queryKey: queryKeys.articles.all },
+        (data) => {
+          if (!data || !("pages" in data)) return data;
+          return {
+            ...data,
+            pages: data.pages.map((page) => ({
+              ...page,
+              items: page.items.map((item) =>
+                item.id === id ? { ...item, is_read: updated.is_read } : item,
+              ),
+            })),
+          };
+        },
+      );
+
+      queryClient.setQueryData<Article>(
+        queryKeys.articles.detail(id),
+        (existing) =>
+          existing ? { ...existing, is_read: updated.is_read } : existing,
+      );
+
+      // Badges are server-computed — invalidate rather than derive client-side.
+      queryClient.invalidateQueries({ queryKey: queryKeys.feeds.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.feedFolders.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.articles.counts });
+    },
+    meta: { errorTitle: "Failed to update article" },
+  });
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,11 @@
-import type { Feed, FeedFolder } from "./types";
+import type {
+  Article,
+  ArticleCounts,
+  ArticleListResponse,
+  Feed,
+  FeedFolder,
+  FeedSelection,
+} from "./types";
 
 /**
  * All API URLs are relative. Dev uses a next.config rewrite that proxies
@@ -36,6 +43,68 @@ export async function fetchFeedFolders(): Promise<FeedFolder[]> {
 
   if (!response.ok) {
     await throwApiError(response, "Failed to fetch feed folders");
+  }
+
+  return response.json();
+}
+
+export async function fetchArticles(
+  selection: FeedSelection,
+  skip: number,
+  limit: number,
+): Promise<ArticleListResponse> {
+  const params = new URLSearchParams({
+    is_read: "false",
+    skip: String(skip),
+    limit: String(limit),
+  });
+  if (selection.type === "feed") {
+    params.set("feed_id", String(selection.id));
+  } else if (selection.type === "folder") {
+    params.set("folder_id", String(selection.id));
+  }
+
+  const response = await fetch(`/api/articles?${params.toString()}`);
+
+  if (!response.ok) {
+    await throwApiError(response, "Failed to fetch articles");
+  }
+
+  return response.json();
+}
+
+export async function fetchArticle(id: number): Promise<Article> {
+  const response = await fetch(`/api/articles/${id}`);
+
+  if (!response.ok) {
+    await throwApiError(response, "Failed to fetch article");
+  }
+
+  return response.json();
+}
+
+export async function updateArticleRead(
+  id: number,
+  isRead: boolean,
+): Promise<Article> {
+  const response = await fetch(`/api/articles/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ is_read: isRead }),
+  });
+
+  if (!response.ok) {
+    await throwApiError(response, "Failed to update article");
+  }
+
+  return response.json();
+}
+
+export async function fetchArticleCounts(): Promise<ArticleCounts> {
+  const response = await fetch("/api/articles/counts");
+
+  if (!response.ok) {
+    await throwApiError(response, "Failed to fetch article counts");
   }
 
   return response.json();

--- a/frontend/src/lib/queryKeys.ts
+++ b/frontend/src/lib/queryKeys.ts
@@ -1,3 +1,20 @@
+import type { FeedSelection } from "./types";
+
+/**
+ * Serialize a `FeedSelection` into a stable, plain-value key segment so the
+ * same scope always produces the same query key regardless of object identity.
+ */
+function selectionKey(selection: FeedSelection): string {
+  switch (selection.type) {
+    case "all":
+      return "all";
+    case "feed":
+      return `feed:${selection.id}`;
+    case "folder":
+      return `folder:${selection.id}`;
+  }
+}
+
 /**
  * Centralized query key factory. Every query key lives here — no inline
  * literals elsewhere. `as const` gives exact tuple types and enables prefix
@@ -10,5 +27,12 @@ export const queryKeys = {
   },
   feedFolders: {
     all: ["feed-folders"] as const,
+  },
+  articles: {
+    all: ["articles"] as const,
+    list: (selection: FeedSelection) =>
+      ["articles", "list", selectionKey(selection)] as const,
+    detail: (id: number) => ["articles", "detail", id] as const,
+    counts: ["articles", "counts"] as const,
   },
 };

--- a/frontend/src/lib/sidebar.test.ts
+++ b/frontend/src/lib/sidebar.test.ts
@@ -35,7 +35,7 @@ describe("buildSidebarModel", () => {
       feed({ id: 11, folder_id: null, title: "Root feed" }),
     ];
 
-    const model = buildSidebarModel(feeds, folders);
+    const model = buildSidebarModel(feeds, folders, null);
 
     expect(model.folders).toHaveLength(1);
     expect(model.folders[0].feeds.map((f) => f.id)).toEqual([10]);
@@ -50,7 +50,7 @@ describe("buildSidebarModel", () => {
       feed({ id: 20, folder_id: 1, display_order: 1 }),
     ];
 
-    const model = buildSidebarModel(feeds, folders);
+    const model = buildSidebarModel(feeds, folders, null);
 
     // display_order 1 (id 10, 20) before display_order 2 (id 30)
     expect(model.folders[0].feeds.map((f) => f.id)).toEqual([10, 20, 30]);
@@ -63,7 +63,7 @@ describe("buildSidebarModel", () => {
       folder({ id: 3, display_order: 1 }),
     ];
 
-    const model = buildSidebarModel([], folders);
+    const model = buildSidebarModel([], folders, null);
 
     expect(model.folders.map((f) => f.id)).toEqual([1, 3, 2]);
   });
@@ -75,7 +75,7 @@ describe("buildSidebarModel", () => {
       feed({ id: 20, display_order: 1 }),
     ];
 
-    const model = buildSidebarModel(feeds, []);
+    const model = buildSidebarModel(feeds, [], null);
 
     expect(model.rootFeeds.map((f) => f.id)).toEqual([10, 20, 30]);
   });
@@ -83,7 +83,7 @@ describe("buildSidebarModel", () => {
   it("keeps an empty folder with no feeds", () => {
     const folders = [folder({ id: 1, name: "Empty", unread_count: 0 })];
 
-    const model = buildSidebarModel([], folders);
+    const model = buildSidebarModel([], folders, null);
 
     expect(model.folders).toHaveLength(1);
     expect(model.folders[0].feeds).toEqual([]);
@@ -96,29 +96,37 @@ describe("buildSidebarModel", () => {
       feed({ id: 11, folder_id: 1, unread_count: 2 }),
     ];
 
-    const model = buildSidebarModel(feeds, folders);
+    const model = buildSidebarModel(feeds, folders, null);
 
     expect(model.folders[0].unread_count).toBe(99);
   });
 
-  it("totals unread by summing feed unread_count across all feeds", () => {
+  it("passes the server-computed global unread through verbatim", () => {
     const folders = [folder({ id: 1, unread_count: 99 })];
     const feeds = [
       feed({ id: 10, folder_id: 1, unread_count: 5 }),
       feed({ id: 11, folder_id: null, unread_count: 3 }),
     ];
 
-    const model = buildSidebarModel(feeds, folders);
+    // Independent of feed/folder counts — never summed client-side.
+    const model = buildSidebarModel(feeds, folders, 42);
 
-    // Sum of feed counts (5 + 3), independent of folder unread_count.
-    expect(model.totalUnread).toBe(8);
+    expect(model.totalUnread).toBe(42);
   });
 
-  it("returns zero totals and empty groups for no data", () => {
-    const model = buildSidebarModel([], []);
+  it("reports null total while counts are loading", () => {
+    const feeds = [feed({ id: 10, unread_count: 5 })];
+
+    const model = buildSidebarModel(feeds, [], null);
+
+    expect(model.totalUnread).toBeNull();
+  });
+
+  it("returns empty groups and null total for no data", () => {
+    const model = buildSidebarModel([], [], null);
 
     expect(model.folders).toEqual([]);
     expect(model.rootFeeds).toEqual([]);
-    expect(model.totalUnread).toBe(0);
+    expect(model.totalUnread).toBeNull();
   });
 });

--- a/frontend/src/lib/sidebar.ts
+++ b/frontend/src/lib/sidebar.ts
@@ -9,7 +9,8 @@ export interface SidebarFolder extends FeedFolder {
 export interface SidebarModel {
   folders: SidebarFolder[];
   rootFeeds: Feed[];
-  totalUnread: number;
+  /** Server-computed global unread; `null` while the counts query is loading. */
+  totalUnread: number | null;
 }
 
 /** Order by `display_order`, then `id` — matching the backend's `GET /api/feeds` ordering. */
@@ -24,12 +25,14 @@ function byDisplayOrder<T extends { display_order: number; id: number }>(
  * Shape live feeds/folders into the ordered sidebar model.
  *
  * Folder unread counts come straight from the folders endpoint (server-computed)
- * and are never recomputed from feed data. `totalUnread` sums feed `unread_count`
- * for presentation — no derivation from article data.
+ * and are never recomputed from feed data. `globalUnread` is the server-computed
+ * total (from the counts endpoint) — passed through verbatim, never derived from
+ * article data. Pass `null` while the counts query is loading.
  */
 export function buildSidebarModel(
   feeds: Feed[],
   folders: FeedFolder[],
+  globalUnread: number | null,
 ): SidebarModel {
   const sortedFolders = [...folders].sort(byDisplayOrder);
   const sortedFeeds = [...feeds].sort(byDisplayOrder);
@@ -54,10 +57,5 @@ export function buildSidebarModel(
     feeds: feedsByFolder.get(folder.id) ?? [],
   }));
 
-  const totalUnread = sortedFeeds.reduce(
-    (sum, feed) => sum + feed.unread_count,
-    0,
-  );
-
-  return { folders: modelFolders, rootFeeds, totalUnread };
+  return { folders: modelFolders, rootFeeds, totalUnread: globalUnread };
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -29,3 +29,69 @@ export type FeedSelection =
 
 /** The default scope — there is never a "nothing selected" state. */
 export const ALL_ARTICLES_SELECTION: FeedSelection = { type: "all" };
+
+/** Mirrors backend `ArticleCategory` (schemas.py). */
+export interface ArticleCategory {
+  id: number;
+  display_name: string;
+  slug: string;
+  effective_weight: number;
+  parent_display_name: string | null;
+}
+
+/** Mirrors backend `ArticleListItem` (schemas.py) — returned by `GET /api/articles`. */
+export interface ArticleListItem {
+  id: number;
+  feed_id: number;
+  feed_title: string;
+  title: string;
+  url: string;
+  author: string | null;
+  published_at: string | null;
+  is_read: boolean;
+  categories: ArticleCategory[] | null;
+  interest_score: number | null;
+  quality_score: number | null;
+  composite_score: number | null;
+  score_reasoning: string | null;
+  summary_preview: string | null;
+  scoring_state: string;
+  scored_at: string | null;
+  re_evaluating: boolean;
+}
+
+/** Mirrors backend response for `GET /api/articles`. */
+export interface ArticleListResponse {
+  items: ArticleListItem[];
+  has_more: boolean;
+}
+
+/** Mirrors backend `ArticleResponse` (schemas.py) — returned by article detail/update endpoints. */
+export interface Article {
+  id: number;
+  feed_id: number;
+  title: string;
+  url: string;
+  author: string | null;
+  published_at: string | null;
+  is_read: boolean;
+  categories: ArticleCategory[] | null;
+  interest_score: number | null;
+  quality_score: number | null;
+  composite_score: number | null;
+  score_reasoning: string | null;
+  scoring_state: string;
+  scored_at: string | null;
+  re_evaluating: boolean;
+  summary: string | null;
+  /** Raw HTML. */
+  content: string | null;
+}
+
+/** Mirrors backend response for `GET /api/articles/counts`. */
+export interface ArticleCounts {
+  unread: number;
+  read: number;
+  scoring: number;
+  blocked: number;
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -30,12 +30,13 @@ export type FeedSelection =
 /** The default scope — there is never a "nothing selected" state. */
 export const ALL_ARTICLES_SELECTION: FeedSelection = { type: "all" };
 
-/** Mirrors backend `ArticleCategory` (schemas.py). */
+/** Mirrors backend `ArticleCategoryEmbed` (schemas.py). */
 export interface ArticleCategory {
   id: number;
   display_name: string;
   slug: string;
-  effective_weight: number;
+  /** Weight label ("block" | "reduce" | "normal" | "boost" | "max") — a string, not a number. */
+  effective_weight: string;
   parent_display_name: string | null;
 }
 

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -4,3 +4,15 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/** "3m" / "5h" / "2d" — compact relative age for `feed · age` meta lines. Empty for null/invalid. */
+export function formatAge(iso: string | null): string {
+  if (!iso) return "";
+  const time = new Date(iso).getTime();
+  if (Number.isNaN(time)) return "";
+  const minutes = Math.max(1, Math.round((Date.now() - time) / 60_000));
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  return `${Math.round(hours / 24)}d`;
+}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -5,10 +5,20 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+/**
+ * Backend datetimes are naive UTC serialized WITHOUT a zone suffix
+ * (e.g. "2026-07-05T21:42:49.090779"). `new Date()` parses offset-less
+ * date-time strings as LOCAL time, so append "Z" to force UTC.
+ */
+export function parseServerDate(iso: string): Date {
+  const hasZone = /(?:Z|[+-]\d{2}:?\d{2})$/i.test(iso);
+  return new Date(hasZone ? iso : `${iso}Z`);
+}
+
 /** "3m" / "5h" / "2d" — compact relative age for `feed · age` meta lines. Empty for null/invalid. */
 export function formatAge(iso: string | null): string {
   if (!iso) return "";
-  const time = new Date(iso).getTime();
+  const time = parseServerDate(iso).getTime();
   if (Number.isNaN(time)) return "";
   const minutes = Math.max(1, Math.round((Date.now() - time) / 60_000));
   if (minutes < 60) return `${minutes}m`;

--- a/frontend/src/test/mocks/handlers/articles.ts
+++ b/frontend/src/test/mocks/handlers/articles.ts
@@ -67,13 +67,18 @@ export const articleHandlers = [
     const url = new URL(request.url);
     const skip = Number(url.searchParams.get("skip") ?? "0");
     const limit = Number(url.searchParams.get("limit") ?? "25");
+    const isReadParam = url.searchParams.get("is_read");
     const feedIdParam = url.searchParams.get("feed_id");
     const folderIdParam = url.searchParams.get("folder_id");
 
     let filtered = mockArticles;
+    if (isReadParam !== null) {
+      // Mirror the backend: is_read filters server-side before pagination.
+      filtered = filtered.filter((a) => String(a.is_read) === isReadParam);
+    }
     if (feedIdParam !== null) {
       const feedId = Number(feedIdParam);
-      filtered = mockArticles.filter((a) => a.feed_id === feedId);
+      filtered = filtered.filter((a) => a.feed_id === feedId);
     } else if (folderIdParam !== null) {
       // No folder fixtures defined — folder scoping yields no matches.
       filtered = [];
@@ -91,7 +96,20 @@ export const articleHandlers = [
 
   http.get("/api/articles/:id", ({ params }) => {
     const id = Number(params.id);
-    return HttpResponse.json({ ...mockArticleDetail, id });
+    // Derive detail fields from the matching list fixture so list and detail
+    // never disagree about the same article (feed, title, read state).
+    const base = mockArticles.find((a) => a.id === id);
+    return HttpResponse.json({
+      ...mockArticleDetail,
+      ...(base && {
+        feed_id: base.feed_id,
+        title: base.title,
+        url: base.url,
+        published_at: base.published_at,
+        is_read: base.is_read,
+      }),
+      id,
+    });
   }),
 
   http.patch("/api/articles/:id", async ({ params, request }) => {

--- a/frontend/src/test/mocks/handlers/articles.ts
+++ b/frontend/src/test/mocks/handlers/articles.ts
@@ -1,0 +1,106 @@
+import { http, HttpResponse } from "msw";
+import type { Article, ArticleCounts, ArticleListItem } from "@/lib/types";
+
+const TOTAL_ARTICLES = 32;
+const FEED_A_ID = 1;
+const FEED_B_ID = 2;
+
+/** Fixture matching the backend `ArticleListItem` shape exactly. 32 unread items split across two feeds. */
+export const mockArticles: ArticleListItem[] = Array.from(
+  { length: TOTAL_ARTICLES },
+  (_, i) => {
+    const id = i + 1;
+    const feedId = id % 2 === 0 ? FEED_A_ID : FEED_B_ID;
+    return {
+      id,
+      feed_id: feedId,
+      feed_title: feedId === FEED_A_ID ? "Feed A" : "Feed B",
+      title: `Article ${id}`,
+      url: `https://example.com/articles/${id}`,
+      author: null,
+      published_at: "2026-07-01T00:00:00",
+      is_read: false,
+      categories: null,
+      interest_score: null,
+      quality_score: null,
+      composite_score: null,
+      score_reasoning: null,
+      summary_preview: `Preview of article ${id}`,
+      scoring_state: "scored",
+      scored_at: null,
+      re_evaluating: false,
+    };
+  },
+);
+
+/** Fixture matching the backend `ArticleResponse` shape exactly. */
+export const mockArticleDetail: Article = {
+  id: 1,
+  feed_id: FEED_B_ID,
+  title: "Article 1",
+  url: "https://example.com/articles/1",
+  author: null,
+  published_at: "2026-07-01T00:00:00",
+  is_read: false,
+  categories: null,
+  interest_score: null,
+  quality_score: null,
+  composite_score: null,
+  score_reasoning: null,
+  scoring_state: "scored",
+  scored_at: null,
+  re_evaluating: false,
+  summary: "Full summary of article 1",
+  content: "<p>Full article content</p>",
+};
+
+/** Fixture matching the backend `GET /api/articles/counts` shape exactly. */
+export const mockArticleCounts: ArticleCounts = {
+  unread: TOTAL_ARTICLES,
+  read: 5,
+  scoring: 1,
+  blocked: 0,
+};
+
+export const articleHandlers = [
+  http.get("/api/articles", ({ request }) => {
+    const url = new URL(request.url);
+    const skip = Number(url.searchParams.get("skip") ?? "0");
+    const limit = Number(url.searchParams.get("limit") ?? "25");
+    const feedIdParam = url.searchParams.get("feed_id");
+    const folderIdParam = url.searchParams.get("folder_id");
+
+    let filtered = mockArticles;
+    if (feedIdParam !== null) {
+      const feedId = Number(feedIdParam);
+      filtered = mockArticles.filter((a) => a.feed_id === feedId);
+    } else if (folderIdParam !== null) {
+      // No folder fixtures defined — folder scoping yields no matches.
+      filtered = [];
+    }
+
+    const items = filtered.slice(skip, skip + limit);
+    const hasMore = skip + limit < filtered.length;
+
+    return HttpResponse.json({ items, has_more: hasMore });
+  }),
+
+  // Must be registered before the `/api/articles/:id` handler — MSW matches
+  // handlers in order, and `:id` would otherwise swallow the literal "counts" segment.
+  http.get("/api/articles/counts", () => HttpResponse.json(mockArticleCounts)),
+
+  http.get("/api/articles/:id", ({ params }) => {
+    const id = Number(params.id);
+    return HttpResponse.json({ ...mockArticleDetail, id });
+  }),
+
+  http.patch("/api/articles/:id", async ({ params, request }) => {
+    const id = Number(params.id);
+    const body = (await request.json()) as { is_read: boolean };
+    return HttpResponse.json({
+      ...mockArticleDetail,
+      id,
+      is_read: body.is_read,
+    });
+  }),
+];

--- a/frontend/src/test/mocks/handlers/index.ts
+++ b/frontend/src/test/mocks/handlers/index.ts
@@ -1,3 +1,4 @@
+import { articleHandlers } from "./articles";
 import { feedHandlers } from "./feeds";
 
-export const handlers = [...feedHandlers];
+export const handlers = [...feedHandlers, ...articleHandlers];


### PR DESCRIPTION
# v2: article list + reader, phone-first

## What is this PR about?

The main reading surface for v2: a relevance-ordered, unread-by-default article list with load-more pagination and read/unread toggling, opening into a full-screen reader with long-form typography and dwell-based mark-as-read. Implements the design decided by the #94 prototype (variant D) and the REST-contract changes it required.

## Why is this change needed?

Until now the v2 shell showed a "No articles" placeholder — this is the core daily-use surface of the app (phone-first, per the PRD). It also locks in the server-side single-definition counts contract that fixes v1's chronically inconsistent unread counts.

## How is this change implemented?

- Backend: `GET /api/articles` returns an `{items, has_more}` envelope with `feed_title`; new `GET /api/articles/counts` computes unread/read/scoring/blocked from shared SQL condition helpers — one definition of "unread" across list, counts, badges, and mark-all-read
- Frontend data layer: TanStack Query hooks (`useArticles` infinite query, `useMarkRead` with in-place cache patching so rows dim rather than vanish, polled `useArticleCounts`), centralized query keys, MSW handlers mirroring the contract
- UI: date-grouped serif-headline list with score/category chips and read-dot toggles; full-screen crossfade reader with DOMPurify-sanitized content, 3s dwell auto-mark, Done pill + Esc close
- Sidebar "All articles" badge now consumes the server-computed global unread count instead of a client-side sum
- A high-effort code review ran over the branch; all 10 verified findings fixed (UTC timestamp parsing, load-more offset drift, unread-definition split, reader error/empty states, and smaller cleanups)

## How to test this change?

1. Start the backend and frontend dev servers, open the app on a phone (or Safari responsive mode at iPhone width)
2. Confirm the list shows unread articles grouped under Today/Yesterday/Earlier, ordered by relevance, with feed name and age on each row
3. Tap a row: the reader opens full-screen; wait ~3 seconds and close via the Done pill — the row should now be dimmed with a hollow dot
4. Tap a row's dot to toggle read/unread without opening the reader
5. Scroll to the end and tap "Load more" to fetch the next page
6. Check the sidebar's "All articles" count matches what the list shows

## Notes

- Unread is now defined as *scored + not blocked + not read* everywhere (CONTEXT.md); a scored zero-score article counts as unread rather than being invisible-but-uncounted
- Offset pagination can still show duplicates if new articles arrive between pages — accepted tradeoff, recorded in the #94 decision comment
- Prototype code from the design phase was throwaway and never committed; the decision record lives on issue #94

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)
