### PR TITLE
v2: desktop on-demand split reader (#95)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,9 +35,6 @@ frontend/bun.lockb
 # MCP plugins
 .playwright-mcp/
 
-# Browser automation
-.rodney/
-
 # IDE
 .idea/
 .vscode/

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -70,7 +70,7 @@
   --card-foreground: oklch(0.147 0.004 49.3);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.147 0.004 49.3);
-  --primary: oklch(0.553 0.195 38.402);
+  --primary: oklch(0.646 0.222 41.116001);
   --primary-foreground: oklch(0.98 0.016 73.684);
   --secondary: oklch(0.967 0.001 286.375);
   --secondary-foreground: oklch(0.21 0.006 285.885);
@@ -105,7 +105,7 @@
   --card-foreground: oklch(0.986 0.002 67.8);
   --popover: oklch(0.214 0.009 43.1);
   --popover-foreground: oklch(0.986 0.002 67.8);
-  --primary: oklch(0.47 0.157 37.304);
+  --primary: oklch(0.646 0.222 41.116001);
   --primary-foreground: oklch(0.98 0.016 73.684);
   --secondary: oklch(0.274 0.006 286.033);
   --secondary-foreground: oklch(0.985 0 0);

--- a/frontend/src/components/article-badges.tsx
+++ b/frontend/src/components/article-badges.tsx
@@ -34,3 +34,66 @@ export function CategoryChip({ label }: { label: string }) {
     </span>
   );
 }
+
+/**
+ * Editorial score readout for the reader header. A refined by-line-style stat
+ * pair: the relevance figure leads in the theme orange with a tabular numeral,
+ * quality sits beside it, each under a small uppercase Inter label. Renders
+ * nothing when both scores are absent. Sans (`font-sans`) keeps the UI
+ * micro-text distinct from the serif reading measure.
+ */
+export function ReaderScores({
+  relevance,
+  quality,
+}: {
+  relevance: number | null;
+  quality: number | null;
+}) {
+  if (relevance === null && quality === null) return null;
+  return (
+    <dl className="flex items-stretch gap-5 font-sans">
+      {relevance !== null && (
+        <ScoreStat label="Relevance" value={relevance.toFixed(1)} accent />
+      )}
+      {relevance !== null && quality !== null && (
+        <div className="border-border/60 border-l" aria-hidden />
+      )}
+      {quality !== null && (
+        <ScoreStat label="Quality" value={`${quality}`} suffix="/10" />
+      )}
+    </dl>
+  );
+}
+
+function ScoreStat({
+  label,
+  value,
+  suffix,
+  accent = false,
+}: {
+  label: string;
+  value: string;
+  suffix?: string;
+  accent?: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <dt className="text-muted-foreground text-[10px] font-medium tracking-[0.14em] uppercase">
+        {label}
+      </dt>
+      <dd
+        className={cn(
+          "text-2xl leading-none font-semibold tabular-nums",
+          accent && "text-primary",
+        )}
+      >
+        {value}
+        {suffix && (
+          <span className="text-muted-foreground ml-0.5 text-sm font-normal">
+            {suffix}
+          </span>
+        )}
+      </dd>
+    </div>
+  );
+}

--- a/frontend/src/components/article-list.test.tsx
+++ b/frontend/src/components/article-list.test.tsx
@@ -16,15 +16,29 @@ import {
  * Render ArticleList directly (no sidebar tree) with its own QueryClient so we
  * keep the tree small and avoid the matchMedia stub the sidebar would need.
  */
-function renderList() {
+function renderList({ readerOpen = false }: { readerOpen?: boolean } = {}) {
   const queryClient = createTestQueryClient();
   const onOpen = vi.fn();
-  render(
+  const { rerender } = render(
     <QueryClientProvider client={queryClient}>
-      <ArticleList selection={{ type: "all" }} onOpen={onOpen} />
+      <ArticleList
+        selection={{ type: "all" }}
+        onOpen={onOpen}
+        readerOpen={readerOpen}
+      />
     </QueryClientProvider>,
   );
-  return { queryClient, onOpen };
+  const setReaderOpen = (open: boolean) =>
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <ArticleList
+          selection={{ type: "all" }}
+          onOpen={onOpen}
+          readerOpen={open}
+        />
+      </QueryClientProvider>,
+    );
+  return { queryClient, onOpen, setReaderOpen };
 }
 
 describe("ArticleList", () => {
@@ -59,6 +73,32 @@ describe("ArticleList", () => {
     expect(
       screen.queryByRole("button", { name: /load more/i }),
     ).not.toBeInTheDocument();
+  });
+
+  it("switches row density when the reader opens and reverts on close", async () => {
+    const { setReaderOpen } = renderList();
+
+    // Rest density by default.
+    const list = (await screen.findByText("Article 2")).closest(
+      "[data-density]",
+    );
+    expect(list).toHaveAttribute("data-density", "rest");
+
+    // Opening the reader signals the list into dense mode...
+    setReaderOpen(true);
+    await waitFor(() =>
+      expect(
+        screen.getByText("Article 2").closest("[data-density]"),
+      ).toHaveAttribute("data-density", "dense"),
+    );
+
+    // ...and closing reverts it.
+    setReaderOpen(false);
+    await waitFor(() =>
+      expect(
+        screen.getByText("Article 2").closest("[data-density]"),
+      ).toHaveAttribute("data-density", "rest"),
+    );
   });
 
   it("marks a row read via the dot toggle and dims the row", async () => {

--- a/frontend/src/components/article-list.tsx
+++ b/frontend/src/components/article-list.tsx
@@ -68,9 +68,8 @@ function ArticleRow({
         !isLast && "border-border/50 border-b",
       )}
     >
-      {/* Overline meta row — the dot is the read toggle.
-          Rest state hides its inline meta at md: (meta moves beside the title);
-          phone and dense state keep it here so those layouts never change. */}
+      {/* Overline meta row — the dot is the read toggle. The meta stays here
+          at every density and breakpoint (phone, dense, and desktop rest). */}
       <div className="text-muted-foreground flex items-center gap-1.5 text-xs">
         <button
           type="button"
@@ -83,37 +82,26 @@ function ArticleRow({
         >
           <ReadDot read={read} />
         </button>
-        <span className={cn("truncate", !dense && "md:hidden")}>{meta}</span>
+        <span className="truncate">{meta}</span>
       </div>
 
-      {/* Rest state at md: places title + excerpt on the left and meta on the
-          right; phone and dense state stack normally. */}
-      <div className={cn(!dense && "md:flex md:items-baseline md:gap-4")}>
-        <div className="min-w-0 md:flex-1">
-          <h3
-            className={cn(
-              "mt-1 font-serif text-xl leading-tight",
-              !read && "font-semibold",
-              // Dense: 2-line clamp at md:. Rest: single-line truncate at md:.
-              dense ? "md:line-clamp-2 md:text-lg" : "md:truncate",
-            )}
-          >
-            {article.title}
-          </h3>
-
-          {/* Excerpt is desktop-only and rest-state-only. */}
-          {!dense && excerpt && (
-            <p className="text-muted-foreground mt-1 hidden truncate text-sm md:block">
-              {excerpt}
-            </p>
+      <div className="min-w-0">
+        <h3
+          className={cn(
+            "mt-1 font-serif text-xl leading-tight",
+            !read && "font-semibold",
+            // Dense: 2-line clamp at md:. Rest: single-line truncate at md:.
+            dense ? "md:line-clamp-2 md:text-lg" : "md:truncate",
           )}
-        </div>
+        >
+          {article.title}
+        </h3>
 
-        {/* Rest-state meta, revealed beside the title at md: only. */}
-        {!dense && (
-          <span className="text-muted-foreground hidden shrink-0 text-xs whitespace-nowrap md:block">
-            {meta}
-          </span>
+        {/* Excerpt is desktop-only and rest-state-only. */}
+        {!dense && excerpt && (
+          <p className="text-muted-foreground mt-1 hidden truncate text-sm md:block">
+            {excerpt}
+          </p>
         )}
       </div>
 

--- a/frontend/src/components/article-list.tsx
+++ b/frontend/src/components/article-list.tsx
@@ -44,16 +44,21 @@ function groupFor(publishedAt: string | null): GroupLabel {
 function ArticleRow({
   article,
   isLast,
+  dense,
   onOpen,
   onToggleRead,
 }: {
   article: ArticleListItem;
   isLast: boolean;
+  /** Desktop split-view density: `true` when the reader pane is open. */
+  dense: boolean;
   onOpen: (article: ArticleListItem) => void;
   onToggleRead: (article: ArticleListItem) => void;
 }) {
   const read = article.is_read;
   const categories = article.categories ?? [];
+  const excerpt = article.summary_preview;
+  const meta = `${article.feed_title} · ${formatAge(article.published_at)}`;
   return (
     <article
       onClick={() => onOpen(article)}
@@ -63,7 +68,9 @@ function ArticleRow({
         !isLast && "border-border/50 border-b",
       )}
     >
-      {/* Overline meta row — the dot is the read toggle */}
+      {/* Overline meta row — the dot is the read toggle.
+          Rest state hides its inline meta at md: (meta moves beside the title);
+          phone and dense state keep it here so those layouts never change. */}
       <div className="text-muted-foreground flex items-center gap-1.5 text-xs">
         <button
           type="button"
@@ -76,19 +83,39 @@ function ArticleRow({
         >
           <ReadDot read={read} />
         </button>
-        <span className="truncate">
-          {article.feed_title} · {formatAge(article.published_at)}
-        </span>
+        <span className={cn("truncate", !dense && "md:hidden")}>{meta}</span>
       </div>
 
-      <h3
-        className={cn(
-          "mt-1 font-serif text-xl leading-tight",
-          !read && "font-semibold",
+      {/* Rest state at md: places title + excerpt on the left and meta on the
+          right; phone and dense state stack normally. */}
+      <div className={cn(!dense && "md:flex md:items-baseline md:gap-4")}>
+        <div className="min-w-0 md:flex-1">
+          <h3
+            className={cn(
+              "mt-1 font-serif text-xl leading-tight",
+              !read && "font-semibold",
+              // Dense: 2-line clamp at md:. Rest: single-line truncate at md:.
+              dense ? "md:line-clamp-2 md:text-lg" : "md:truncate",
+            )}
+          >
+            {article.title}
+          </h3>
+
+          {/* Excerpt is desktop-only and rest-state-only. */}
+          {!dense && excerpt && (
+            <p className="text-muted-foreground mt-1 hidden truncate text-sm md:block">
+              {excerpt}
+            </p>
+          )}
+        </div>
+
+        {/* Rest-state meta, revealed beside the title at md: only. */}
+        {!dense && (
+          <span className="text-muted-foreground hidden shrink-0 text-xs whitespace-nowrap md:block">
+            {meta}
+          </span>
         )}
-      >
-        {article.title}
-      </h3>
+      </div>
 
       {(article.composite_score !== null || categories.length > 0) && (
         <div className="mt-2 flex flex-wrap items-center gap-1.5">
@@ -107,9 +134,19 @@ function ArticleRow({
 interface ArticleListProps {
   selection: FeedSelection;
   onOpen: (article: ArticleListItem) => void;
+  /**
+   * Whether the reader pane is open. Drives the desktop split-view row density
+   * (a prop, not a media query — phone rows are unaffected). `data-density`
+   * exposes the resolved value for tests.
+   */
+  readerOpen?: boolean;
 }
 
-export function ArticleList({ selection, onOpen }: ArticleListProps) {
+export function ArticleList({
+  selection,
+  onOpen,
+  readerOpen = false,
+}: ArticleListProps) {
   const {
     articles,
     isPending,
@@ -174,7 +211,10 @@ export function ArticleList({ selection, onOpen }: ArticleListProps) {
   }
 
   return (
-    <div className="h-full overflow-y-auto">
+    <div
+      className="h-full overflow-y-auto"
+      data-density={readerOpen ? "dense" : "rest"}
+    >
       {groups.map((group) => (
         <section key={group.label}>
           <h2 className="bg-background text-muted-foreground sticky top-0 px-4 pt-4 pb-1 text-xs font-medium tracking-wide uppercase">
@@ -185,6 +225,7 @@ export function ArticleList({ selection, onOpen }: ArticleListProps) {
               key={article.id}
               article={article}
               isLast={i === group.items.length - 1}
+              dense={readerOpen}
               onOpen={onOpen}
               onToggleRead={toggleRead}
             />

--- a/frontend/src/components/article-reader.test.tsx
+++ b/frontend/src/components/article-reader.test.tsx
@@ -67,8 +67,9 @@ describe("ArticleReader", () => {
       screen.getByRole("heading", { name: "Article 1" }),
     ).toBeInTheDocument();
     expect(screen.getByText(/Feed B/)).toBeInTheDocument();
-    expect(screen.getByText("relevance 17.4")).toBeInTheDocument();
-    expect(screen.getByText("quality 8/10")).toBeInTheDocument();
+    expect(screen.getByText("Relevance")).toBeInTheDocument();
+    expect(screen.getByText("17.4")).toBeInTheDocument();
+    expect(screen.getByText("Quality")).toBeInTheDocument();
     expect(
       screen.getByText("Directly relevant to your interests."),
     ).toBeInTheDocument();
@@ -98,15 +99,30 @@ describe("ArticleReader", () => {
     expect(img?.getAttribute("onerror")).toBeNull();
   });
 
-  it("calls onClose on the Done button and on Escape", async () => {
+  it("calls onClose on the Close button and on Escape", async () => {
     const user = userEvent.setup();
     const { onClose } = renderReader(listItem());
 
-    await user.click(screen.getByRole("button", { name: /done/i }));
+    // The phone pill now reads "Close" (there is also a desktop-only icon-only
+    // Close button — both share the same aria-label).
+    const closeButtons = screen.getAllByRole("button", { name: /close/i });
+    expect(closeButtons.some((b) => b.textContent?.includes("Close"))).toBe(
+      true,
+    );
+    await user.click(closeButtons[0]);
     expect(onClose).toHaveBeenCalledTimes(1);
 
     await user.keyboard("{Escape}");
     expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows the interest and quality scores in the editorial readout", () => {
+    renderReader(listItem({ composite_score: 17.4, quality_score: 8 }));
+
+    expect(screen.getByText("Relevance")).toBeInTheDocument();
+    expect(screen.getByText("17.4")).toBeInTheDocument();
+    expect(screen.getByText("Quality")).toBeInTheDocument();
+    expect(screen.getByText("8")).toBeInTheDocument();
   });
 
   it("auto-marks the article read after the dwell window", async () => {

--- a/frontend/src/components/article-reader.tsx
+++ b/frontend/src/components/article-reader.tsx
@@ -1,10 +1,14 @@
 "use client";
 
 import DOMPurify from "dompurify";
-import { Check } from "lucide-react";
+import { X } from "lucide-react";
 import { useEffect, useMemo } from "react";
 
-import { CategoryChip, ReadDot } from "@/components/article-badges";
+import {
+  CategoryChip,
+  ReadDot,
+  ReaderScores,
+} from "@/components/article-badges";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useArticle } from "@/hooks/useArticle";
@@ -71,7 +75,16 @@ export function ArticleReader({
   }, [articleId, wasUnreadAtOpen, contentLoaded, dwellMs, markMutate]);
 
   return (
-    <div className="bg-background animate-in fade-in fixed inset-0 z-40 flex flex-col duration-200">
+    <div className="bg-background animate-in fade-in md:slide-in-from-right fixed inset-0 z-40 flex flex-col duration-200 md:static md:z-auto md:min-w-0 md:flex-1">
+      {/* Desktop close affordance — top-right of the reader pane. */}
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label="Close"
+        className="text-muted-foreground hover:bg-muted hover:text-foreground absolute top-4 right-4 z-10 hidden size-9 items-center justify-center rounded-full transition-colors md:flex"
+      >
+        <X className="size-5" />
+      </button>
       <div className="min-h-0 flex-1 overflow-y-auto">
         <div className="px-5 pt-10 pb-24">
           <div className="mx-auto max-w-[68ch]">
@@ -93,18 +106,11 @@ export function ArticleReader({
               {article.feed_title} · {formatAge(article.published_at)}
             </p>
 
-            <div className="mt-4 space-y-3">
-              {(article.composite_score !== null ||
-                article.quality_score !== null) && (
-                <div className="text-muted-foreground flex flex-wrap items-center gap-x-4 gap-y-1 text-xs">
-                  {article.composite_score !== null && (
-                    <span>relevance {article.composite_score.toFixed(1)}</span>
-                  )}
-                  {article.quality_score !== null && (
-                    <span>quality {article.quality_score}/10</span>
-                  )}
-                </div>
-              )}
+            <div className="mt-5 space-y-4">
+              <ReaderScores
+                relevance={article.composite_score}
+                quality={article.quality_score}
+              />
               {article.score_reasoning !== null && (
                 <blockquote className="text-muted-foreground border-l-2 pl-3 font-serif text-sm italic">
                   {article.score_reasoning}
@@ -150,7 +156,7 @@ export function ArticleReader({
             </p>
           ) : (
             <div
-              className="[&_blockquote]:text-muted-foreground mx-auto mt-6 max-w-[68ch] font-serif text-[17px] leading-[1.7] [&_a]:underline [&_blockquote]:border-l-2 [&_blockquote]:pl-4 [&_blockquote]:italic [&_h2]:mt-8 [&_h2]:mb-2 [&_h2]:text-xl [&_h2]:font-semibold [&_img]:max-w-full [&_li]:mt-1 [&_p]:mt-4 [&_pre]:overflow-x-auto [&_ul]:mt-4 [&_ul]:list-disc [&_ul]:pl-5"
+              className="[&_blockquote]:text-muted-foreground [&_a]:text-primary [&_a]:decoration-primary/40 [&_a:hover]:decoration-primary mx-auto mt-6 max-w-[68ch] font-serif text-[17px] leading-[1.7] [&_a]:underline [&_a]:underline-offset-2 [&_blockquote]:border-l-2 [&_blockquote]:pl-4 [&_blockquote]:italic [&_h2]:mt-8 [&_h2]:mb-2 [&_h2]:text-xl [&_h2]:font-semibold [&_img]:max-w-full [&_li]:mt-1 [&_p]:mt-4 [&_pre]:overflow-x-auto [&_ul]:mt-4 [&_ul]:list-disc [&_ul]:pl-5"
               dangerouslySetInnerHTML={{ __html: bodyHtml }}
             />
           )}
@@ -158,10 +164,10 @@ export function ArticleReader({
       </div>
       <Button
         onClick={onClose}
-        className="fixed bottom-6 left-1/2 z-50 -translate-x-1/2 rounded-full shadow-lg"
+        className="fixed bottom-6 left-1/2 z-50 -translate-x-1/2 rounded-full shadow-lg md:hidden"
       >
-        <Check />
-        Done
+        <X />
+        Close
       </Button>
     </div>
   );

--- a/frontend/src/components/article-reader.tsx
+++ b/frontend/src/components/article-reader.tsx
@@ -88,78 +88,83 @@ export function ArticleReader({
       <div className="min-h-0 flex-1 overflow-y-auto">
         <div className="px-5 pt-10 pb-24">
           <div className="mx-auto max-w-[68ch]">
-            {/* Overline: live read status + category chips, above the headline */}
-            <div className="mb-3 flex flex-wrap items-center gap-1.5">
-              <span className="text-muted-foreground mr-1 flex items-center gap-1.5 text-xs">
-                <ReadDot read={isRead} />
-                {isRead ? "Read" : "Unread"}
-              </span>
-              {categories.map((category) => (
-                <CategoryChip key={category.id} label={category.display_name} />
-              ))}
+            <div>
+              {/* Overline: live read status + category chips, above the headline */}
+              <div className="mb-3 flex flex-wrap items-center gap-1.5">
+                <span className="text-muted-foreground mr-1 flex items-center gap-1.5 text-xs">
+                  <ReadDot read={isRead} />
+                  {isRead ? "Read" : "Unread"}
+                </span>
+                {categories.map((category) => (
+                  <CategoryChip
+                    key={category.id}
+                    label={category.display_name}
+                  />
+                ))}
+              </div>
+
+              <h1 className="font-serif text-3xl leading-tight font-bold">
+                {article.title}
+              </h1>
+              <p className="text-muted-foreground mt-2 text-sm">
+                {article.feed_title} · {formatAge(article.published_at)}
+              </p>
+
+              <div className="mt-5 space-y-4">
+                <ReaderScores
+                  relevance={article.composite_score}
+                  quality={article.quality_score}
+                />
+                {article.score_reasoning !== null && (
+                  <blockquote className="text-muted-foreground border-l-2 pl-3 font-serif text-sm italic">
+                    {article.score_reasoning}
+                  </blockquote>
+                )}
+              </div>
             </div>
 
-            <h1 className="font-serif text-3xl leading-tight font-bold">
-              {article.title}
-            </h1>
-            <p className="text-muted-foreground mt-2 text-sm">
-              {article.feed_title} · {formatAge(article.published_at)}
-            </p>
-
-            <div className="mt-5 space-y-4">
-              <ReaderScores
-                relevance={article.composite_score}
-                quality={article.quality_score}
+            {detailQuery.isError ? (
+              <p className="text-muted-foreground mt-8 text-sm">
+                Couldn&apos;t load this article.{" "}
+                <a
+                  href={article.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="underline"
+                >
+                  Open the original
+                </a>
+              </p>
+            ) : detailQuery.isPending ? (
+              <div className="mt-8 space-y-3">
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-[92%]" />
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-[85%]" />
+                <Skeleton className="h-4 w-[70%]" />
+                <Skeleton className="mt-6 h-4 w-full" />
+                <Skeleton className="h-4 w-[88%]" />
+                <Skeleton className="h-4 w-[60%]" />
+              </div>
+            ) : bodyHtml === null ? (
+              <p className="text-muted-foreground mt-8 text-sm">
+                This article has no content.{" "}
+                <a
+                  href={article.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="underline"
+                >
+                  Open the original
+                </a>
+              </p>
+            ) : (
+              <div
+                className="[&_blockquote]:text-muted-foreground [&_a]:text-primary [&_a]:decoration-primary/40 [&_a:hover]:decoration-primary mt-6 font-serif text-[17px] leading-[1.7] [&_a]:underline [&_a]:underline-offset-2 [&_blockquote]:border-l-2 [&_blockquote]:pl-4 [&_blockquote]:italic [&_h2]:mt-8 [&_h2]:mb-2 [&_h2]:text-xl [&_h2]:font-semibold [&_img]:max-w-full [&_li]:mt-1 [&_p]:mt-4 [&_pre]:overflow-x-auto [&_ul]:mt-4 [&_ul]:list-disc [&_ul]:pl-5"
+                dangerouslySetInnerHTML={{ __html: bodyHtml }}
               />
-              {article.score_reasoning !== null && (
-                <blockquote className="text-muted-foreground border-l-2 pl-3 font-serif text-sm italic">
-                  {article.score_reasoning}
-                </blockquote>
-              )}
-            </div>
+            )}
           </div>
-
-          {detailQuery.isError ? (
-            <p className="text-muted-foreground mx-auto mt-8 max-w-[68ch] text-sm">
-              Couldn&apos;t load this article.{" "}
-              <a
-                href={article.url}
-                target="_blank"
-                rel="noreferrer"
-                className="underline"
-              >
-                Open the original
-              </a>
-            </p>
-          ) : detailQuery.isPending ? (
-            <div className="mx-auto mt-8 max-w-[68ch] space-y-3">
-              <Skeleton className="h-4 w-full" />
-              <Skeleton className="h-4 w-[92%]" />
-              <Skeleton className="h-4 w-full" />
-              <Skeleton className="h-4 w-[85%]" />
-              <Skeleton className="h-4 w-[70%]" />
-              <Skeleton className="mt-6 h-4 w-full" />
-              <Skeleton className="h-4 w-[88%]" />
-              <Skeleton className="h-4 w-[60%]" />
-            </div>
-          ) : bodyHtml === null ? (
-            <p className="text-muted-foreground mx-auto mt-8 max-w-[68ch] text-sm">
-              This article has no content.{" "}
-              <a
-                href={article.url}
-                target="_blank"
-                rel="noreferrer"
-                className="underline"
-              >
-                Open the original
-              </a>
-            </p>
-          ) : (
-            <div
-              className="[&_blockquote]:text-muted-foreground [&_a]:text-primary [&_a]:decoration-primary/40 [&_a:hover]:decoration-primary mx-auto mt-6 max-w-[68ch] font-serif text-[17px] leading-[1.7] [&_a]:underline [&_a]:underline-offset-2 [&_blockquote]:border-l-2 [&_blockquote]:pl-4 [&_blockquote]:italic [&_h2]:mt-8 [&_h2]:mb-2 [&_h2]:text-xl [&_h2]:font-semibold [&_img]:max-w-full [&_li]:mt-1 [&_p]:mt-4 [&_pre]:overflow-x-auto [&_ul]:mt-4 [&_ul]:list-disc [&_ul]:pl-5"
-              dangerouslySetInnerHTML={{ __html: bodyHtml }}
-            />
-          )}
         </div>
       </div>
       <Button

--- a/frontend/src/components/home-shell.tsx
+++ b/frontend/src/components/home-shell.tsx
@@ -23,6 +23,7 @@ import {
   type ArticleListItem,
   type FeedSelection,
 } from "@/lib/types";
+import { cn } from "@/lib/utils";
 
 const SELECTION_STORAGE_KEY = "rss-reader:selection";
 
@@ -67,8 +68,24 @@ export function HomeShell() {
           <SidebarTrigger />
           <h1 className="text-sm font-medium">{header}</h1>
         </header>
-        <main className="flex min-h-0 flex-1 flex-col overflow-hidden">
-          <ArticleList selection={selection} onOpen={setOpenArticle} />
+        <main className="flex min-h-0 flex-1 flex-col overflow-hidden md:flex-row">
+          {/* List column: full width by default; animates to a fixed 380px
+              column at md: when the reader is open (phone stays full-bleed).
+              cn keeps the width classes readable. */}
+          <div
+            className={cn(
+              "min-h-0 flex-1 transition-[width] duration-300 md:flex-none",
+              openArticle !== null
+                ? "md:w-[380px] md:shrink-0 md:border-r"
+                : "md:w-full",
+            )}
+          >
+            <ArticleList
+              selection={selection}
+              onOpen={setOpenArticle}
+              readerOpen={openArticle !== null}
+            />
+          </div>
           {openArticle !== null && (
             <ArticleReader
               article={openArticle}


### PR DESCRIPTION
# v2: desktop on-demand split reader (#95)

## What is this PR about?

Implements the desktop reader presentation decided in #93: at desktop widths the article list narrows to a 380px column while the reader slides in as a side pane; phone keeps its full-screen overlay reader unchanged.

## Why is this change needed?

Closes #95. The v2 reader was phone-first only — on a laptop the full-screen overlay wasted the wide screen and hid read-state changes behind it.

## How is this change implemented?

- One component tree across breakpoints: the reader's container switches from `fixed inset-0` overlay to an in-flow flex pane via `md:` classes only — no duplicated per-breakpoint subtrees, no `useIsMobile` render forks
- Row density is driven by "is the reader open" state (a prop, not a media query): full-width rows with excerpts at rest, 2-line clamped titles while reading; all desktop-only via `md:` gating
- Close affordances: desktop X in the pane's top-right + Esc; the phone pill renamed "Done" → "Close" with an X icon
- Reader polish: article-body links in theme orange, a more visible Relevance/Quality readout in the header, and a shared column measure so header and body edges align
- Theme primary brightened to orange-600 in both themes; stale `.rodney/` gitignore section dropped

## How to test this change?

1. Open the app in a desktop browser (≥768px wide) — the article list should fill the content width with excerpts in the rows.
2. Click an article — the list should ease down to a narrow column while the reader appears on the right; both should scroll independently.
3. Close with the X (top-right) or Esc — the list grows back to full width.
4. Narrow the window below 768px (or use a phone) — the reader should open full-screen exactly as before, with the floating pill now reading "Close".
5. Check article links and the Relevance figure render in the orange accent in both light and dark mode.

## Notes

- Exit animation for the reader pane was deliberately deferred (the pane disappears instantly while the list width animates) — recorded as acceptable for now, easy to add later.
- The #93-decided measure floor (~60ch at 1280px with the sidebar open) holds; nothing else claims width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)