### PR TITLE
v2: settings UI — interests editor + scoring-progress chip

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,6 +28,14 @@ _Avoid_: suggestion, suggested category
 Reviewing LLM-created categories after the fact — keep, rename, merge, or block. New categories are live and usable from the moment of creation; triage is cleanup, never an approval gate.
 _Avoid_: category approval, moderation queue
 
+**Interests**:
+Free prose in which the reader describes what they want to read, fed to the scoring LLM to steer relevance with natural-language nuance a keyword list can't capture.
+_Avoid_: keywords, filters, rules
+
+**Anti-interests**:
+The counterpart prose describing what the reader wants to see less of. Steers the scoring LLM toward a lower score — distinct from Weight (a per-category stance) and Blocked (absolute suppression), which act on categories, not prose.
+_Avoid_: blocklist, mute list, exclusions
+
 **Reader**:
 The article reading surface. Full-screen on the phone (the primary device); its desktop presentation (sheet vs. split pane) is a prototype-decided detail. One component tree across breakpoints, never parallel layouts.
 _Avoid_: detail view, drawer, article page

--- a/frontend/src/app/settings/interests/page.tsx
+++ b/frontend/src/app/settings/interests/page.tsx
@@ -1,10 +1,5 @@
-import { SettingsPlaceholder } from "@/components/settings-placeholder";
+import { InterestsSettings } from "@/components/interests-settings";
 
 export default function InterestsSettingsPage() {
-  return (
-    <SettingsPlaceholder
-      title="Interests"
-      blurb="Describe what you care about to steer relevance scoring."
-    />
-  );
+  return <InterestsSettings />;
 }

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -62,6 +62,7 @@ import {
   SidebarMenuSubButton,
   SidebarMenuSubItem,
 } from "@/components/ui/sidebar";
+import { ScoringStatusChip } from "@/components/scoring-status-chip";
 import { ThemeToggle } from "@/components/theme-toggle";
 
 /** De-emphasize fully-read feeds (unread === 0) per the read-visual convention. */
@@ -475,6 +476,7 @@ export function AppSidebar({ selection, onSelect }: AppSidebarProps) {
       </SidebarContent>
 
       <SidebarFooter>
+        <ScoringStatusChip />
         <Button
           variant="outline"
           size="sm"

--- a/frontend/src/components/interests-settings.test.tsx
+++ b/frontend/src/components/interests-settings.test.tsx
@@ -1,0 +1,93 @@
+import { http, HttpResponse } from "msw";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { InterestsSettings } from "@/components/interests-settings";
+import { mockPreferences } from "@/test/mocks/handlers/preferences";
+import { server } from "@/test/mocks/server";
+import { renderWithProviders, screen, userEvent, waitFor } from "@/test/utils";
+import type { PreferencesUpdate } from "@/lib/types";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/settings/interests",
+}));
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ setTheme: vi.fn(), theme: "light" }),
+}));
+
+beforeAll(() => {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+});
+
+describe("InterestsSettings", () => {
+  it("round-trips an edit: loads current values, saves both fields, and resets the baseline", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<InterestsSettings />);
+
+    const interestsField = (await screen.findByLabelText(
+      "Interests",
+    )) as HTMLTextAreaElement;
+    const antiInterestsField = screen.getByLabelText(
+      "Anti-interests",
+    ) as HTMLTextAreaElement;
+
+    await waitFor(() => {
+      expect(interestsField.value).toBe(mockPreferences.interests);
+      expect(antiInterestsField.value).toBe(mockPreferences.anti_interests);
+    });
+
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    expect(saveButton).toBeDisabled();
+
+    const newInterests = "space exploration, robotics";
+    await user.clear(interestsField);
+    await user.type(interestsField, newInterests);
+
+    let captured: PreferencesUpdate | null = null;
+    server.use(
+      http.put("/api/preferences", async ({ request }) => {
+        captured = (await request.json()) as PreferencesUpdate;
+        // The mutation success handler invalidates the GET query, so the
+        // refetch must also reflect the saved state (and its bumped
+        // `updated_at`) for the form to remount with a reset baseline.
+        server.use(
+          http.get("/api/preferences", () =>
+            HttpResponse.json({
+              ...mockPreferences,
+              ...captured,
+              updated_at: "2026-02-02T00:00:00",
+            }),
+          ),
+        );
+        return HttpResponse.json({
+          ...mockPreferences,
+          ...captured,
+          updated_at: "2026-02-02T00:00:00",
+        });
+      }),
+    );
+
+    expect(saveButton).toBeEnabled();
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(captured).not.toBeNull();
+    });
+    expect(captured!.interests).toBe(newInterests);
+    expect(captured!.anti_interests).toBe(mockPreferences.anti_interests);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    });
+  });
+});

--- a/frontend/src/components/interests-settings.tsx
+++ b/frontend/src/components/interests-settings.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { toast } from "sonner";
 
 import { usePreferences } from "@/hooks/usePreferences";
 import { useUpdatePreferences } from "@/hooks/useUpdatePreferences";
@@ -25,10 +26,10 @@ function InterestsForm({ initial }: { initial: Preferences }) {
       className="flex flex-col gap-5"
       onSubmit={(event) => {
         event.preventDefault();
-        updatePreferences.mutate({
-          interests,
-          anti_interests: antiInterests,
-        });
+        updatePreferences.mutate(
+          { interests, anti_interests: antiInterests },
+          { onSuccess: () => toast.success("Interests saved") },
+        );
       }}
     >
       <Field>
@@ -61,7 +62,7 @@ function InterestsForm({ initial }: { initial: Preferences }) {
       </Field>
       <Button
         type="submit"
-        className="h-11 self-start sm:h-9"
+        className="h-11 self-end sm:h-9"
         disabled={!isDirty || updatePreferences.isPending}
       >
         {updatePreferences.isPending ? "Saving…" : "Save"}

--- a/frontend/src/components/interests-settings.tsx
+++ b/frontend/src/components/interests-settings.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState } from "react";
+
+import { usePreferences } from "@/hooks/usePreferences";
+import { useUpdatePreferences } from "@/hooks/useUpdatePreferences";
+import type { Preferences } from "@/lib/types";
+import { Button } from "@/components/ui/button";
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Textarea } from "@/components/ui/textarea";
+
+/** Form body — keyed by `updated_at` at the call site so a successful save
+ * (which bumps `updated_at` server-side) remounts it and resets the baseline. */
+function InterestsForm({ initial }: { initial: Preferences }) {
+  const [interests, setInterests] = useState(initial.interests);
+  const [antiInterests, setAntiInterests] = useState(initial.anti_interests);
+  const updatePreferences = useUpdatePreferences();
+
+  const isDirty =
+    interests !== initial.interests || antiInterests !== initial.anti_interests;
+
+  return (
+    <form
+      className="flex flex-col gap-5"
+      onSubmit={(event) => {
+        event.preventDefault();
+        updatePreferences.mutate({
+          interests,
+          anti_interests: antiInterests,
+        });
+      }}
+    >
+      <Field>
+        <FieldLabel htmlFor="interests">Interests</FieldLabel>
+        <Textarea
+          id="interests"
+          placeholder="e.g. AI research, distributed systems, climate tech — describe what you want to read more of"
+          className="min-h-32"
+          value={interests}
+          onChange={(event) => setInterests(event.target.value)}
+          disabled={updatePreferences.isPending}
+        />
+        <FieldDescription>
+          Steers scoring toward articles matching these topics.
+        </FieldDescription>
+      </Field>
+      <Field>
+        <FieldLabel htmlFor="anti-interests">Anti-interests</FieldLabel>
+        <Textarea
+          id="anti-interests"
+          placeholder="e.g. celebrity gossip, sports scores — describe what you want to see less of"
+          className="min-h-32"
+          value={antiInterests}
+          onChange={(event) => setAntiInterests(event.target.value)}
+          disabled={updatePreferences.isPending}
+        />
+        <FieldDescription>
+          Steers scoring away from articles matching these topics.
+        </FieldDescription>
+      </Field>
+      <Button
+        type="submit"
+        className="h-11 self-start sm:h-9"
+        disabled={!isDirty || updatePreferences.isPending}
+      >
+        {updatePreferences.isPending ? "Saving…" : "Save"}
+      </Button>
+    </form>
+  );
+}
+
+/** The Interests settings section — free-text interests/anti-interests that steer LLM relevance scoring. */
+export function InterestsSettings() {
+  const { data, isPending, isError } = usePreferences();
+
+  return (
+    <div className="flex flex-col gap-5">
+      <h2 className="text-lg font-semibold">Interests</h2>
+
+      {isPending ? (
+        <div className="flex flex-col gap-5">
+          <Skeleton className="h-32 w-full" />
+          <Skeleton className="h-32 w-full" />
+        </div>
+      ) : isError ? (
+        <p className="text-muted-foreground text-sm">
+          Couldn&apos;t load your interests. Retrying…
+        </p>
+      ) : (
+        <InterestsForm key={data.updated_at} initial={data} />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/scoring-status-chip.test.tsx
+++ b/frontend/src/components/scoring-status-chip.test.tsx
@@ -1,0 +1,61 @@
+import { http, HttpResponse } from "msw";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { ScoringStatusChip } from "@/components/scoring-status-chip";
+import type { ScoringStatus } from "@/lib/types";
+import { server } from "@/test/mocks/server";
+import { renderWithProviders, screen, waitFor } from "@/test/utils";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/",
+}));
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ setTheme: vi.fn(), theme: "dark" }),
+}));
+
+beforeAll(() => {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+});
+
+describe("ScoringStatusChip", () => {
+  it("shows the sum of non-terminal counts while work is pending", async () => {
+    const pending: ScoringStatus = {
+      unscored: 1,
+      queued: 2,
+      scoring: 0,
+      scored: 50,
+      failed: 1,
+      blocked: 4,
+      phase: "scoring",
+    };
+    server.use(
+      http.get("/api/scoring/status", () => HttpResponse.json(pending)),
+    );
+
+    renderWithProviders(<ScoringStatusChip />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/Processing/)).toHaveTextContent("Processing 3…"),
+    );
+  });
+
+  it("renders nothing when idle (all counts zero)", async () => {
+    renderWithProviders(<ScoringStatusChip />);
+
+    await waitFor(() =>
+      expect(screen.queryByRole("status")).not.toBeInTheDocument(),
+    );
+    expect(screen.queryByText(/processing/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/scoring-status-chip.test.tsx
+++ b/frontend/src/components/scoring-status-chip.test.tsx
@@ -46,7 +46,9 @@ describe("ScoringStatusChip", () => {
     renderWithProviders(<ScoringStatusChip />);
 
     await waitFor(() =>
-      expect(screen.getByText(/Processing/)).toHaveTextContent("Processing 3…"),
+      expect(screen.getByText(/Processing/)).toHaveTextContent(
+        "Processing 3 articles",
+      ),
     );
   });
 

--- a/frontend/src/components/scoring-status-chip.tsx
+++ b/frontend/src/components/scoring-status-chip.tsx
@@ -18,15 +18,16 @@ export function ScoringStatusChip() {
     <div
       role="status"
       aria-live="polite"
-      className="text-muted-foreground flex items-center gap-2 px-2 text-xs"
+      className="text-muted-foreground mb-2 flex items-center gap-2 px-2 text-xs"
     >
+      <span aria-hidden>
+        Processing <span className="tabular-nums">{pending}</span>{" "}
+        {pending === 1 ? "article" : "articles"}
+      </span>
       <span
         aria-hidden
-        className="bg-primary size-1.5 shrink-0 animate-pulse rounded-full"
+        className="bg-primary ml-auto size-1.5 shrink-0 animate-pulse rounded-full"
       />
-      <span aria-hidden>
-        Processing <span className="tabular-nums">{pending}</span>…
-      </span>
       <span className="sr-only">{pending} articles left to process</span>
     </div>
   );

--- a/frontend/src/components/scoring-status-chip.tsx
+++ b/frontend/src/components/scoring-status-chip.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useScoringStatus } from "@/hooks/useScoringStatus";
+import { scoringPendingCount } from "@/lib/utils";
+
+/**
+ * Quiet-when-idle status row for the sidebar footer — shows how many articles
+ * are still queued/scoring, or renders nothing. Non-interactive (no
+ * link/button): there's no navigation target for scoring progress yet.
+ */
+export function ScoringStatusChip() {
+  const { data } = useScoringStatus();
+  const pending = scoringPendingCount(data);
+
+  if (pending <= 0) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="text-muted-foreground flex items-center gap-2 px-2 text-xs"
+    >
+      <span
+        aria-hidden
+        className="bg-primary size-1.5 shrink-0 animate-pulse rounded-full"
+      />
+      <span aria-hidden>
+        Processing <span className="tabular-nums">{pending}</span>…
+      </span>
+      <span className="sr-only">{pending} articles left to process</span>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:ring-destructive/40 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Textarea };

--- a/frontend/src/hooks/usePreferences.ts
+++ b/frontend/src/hooks/usePreferences.ts
@@ -1,0 +1,12 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { fetchPreferences } from "@/lib/api";
+import { queryKeys } from "@/lib/queryKeys";
+
+export function usePreferences() {
+  return useQuery({
+    queryKey: queryKeys.preferences.detail,
+    queryFn: fetchPreferences,
+  });
+}

--- a/frontend/src/hooks/useScoringStatus.ts
+++ b/frontend/src/hooks/useScoringStatus.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { fetchScoringStatus } from "@/lib/api";
+import {
+  SCORING_STATUS_POLL_ACTIVE,
+  SCORING_STATUS_POLL_IDLE,
+} from "@/lib/constants";
+import { queryKeys } from "@/lib/queryKeys";
+import { scoringPendingCount } from "@/lib/utils";
+
+export function useScoringStatus() {
+  return useQuery({
+    queryKey: queryKeys.scoring.status,
+    queryFn: fetchScoringStatus,
+    refetchInterval: (query) =>
+      scoringPendingCount(query.state.data) > 0
+        ? SCORING_STATUS_POLL_ACTIVE
+        : SCORING_STATUS_POLL_IDLE,
+  });
+}

--- a/frontend/src/hooks/useUpdatePreferences.ts
+++ b/frontend/src/hooks/useUpdatePreferences.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { updatePreferences } from "@/lib/api";
+import { queryKeys } from "@/lib/queryKeys";
+import type { PreferencesUpdate } from "@/lib/types";
+
+export function useUpdatePreferences() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (update: PreferencesUpdate) => updatePreferences(update),
+    onSuccess: (data) => {
+      // Write the authoritative PUT response straight to cache so the interests
+      // form's remount-reset (keyed on updated_at) is deterministic and doesn't
+      // hinge on a follow-up refetch that could fail. Interests/anti-interests
+      // changes trigger a server-side rescore, so wake the scoring chip too.
+      queryClient.setQueryData(queryKeys.preferences.detail, data);
+      queryClient.invalidateQueries({ queryKey: queryKeys.scoring.status });
+    },
+    meta: { errorTitle: "Couldn't save your interests" },
+  });
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -20,6 +20,9 @@ import type {
   FeedFolderUpdatePayload,
   FeedSelection,
   FeedUpdatePayload,
+  Preferences,
+  PreferencesUpdate,
+  ScoringStatus,
 } from "./types";
 
 /**
@@ -365,6 +368,42 @@ export async function autoGroupApply(
 
   if (!response.ok) {
     await throwApiError(response, "Failed to apply category groups");
+  }
+
+  return response.json();
+}
+
+export async function fetchPreferences(): Promise<Preferences> {
+  const response = await fetch("/api/preferences");
+
+  if (!response.ok) {
+    await throwApiError(response, "Failed to fetch preferences");
+  }
+
+  return response.json();
+}
+
+export async function updatePreferences(
+  update: PreferencesUpdate,
+): Promise<Preferences> {
+  const response = await fetch("/api/preferences", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(update),
+  });
+
+  if (!response.ok) {
+    await throwApiError(response, "Failed to update preferences");
+  }
+
+  return response.json();
+}
+
+export async function fetchScoringStatus(): Promise<ScoringStatus> {
+  const response = await fetch("/api/scoring/status");
+
+  if (!response.ok) {
+    await throwApiError(response, "Failed to fetch scoring status");
   }
 
   return response.json();

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -44,3 +44,9 @@ export const CATEGORY_WEIGHT_ICON: Record<CategoryWeight, LucideIcon> = {
 
 /** How long a triage Keep/Block decision stays undoable before the mutation fires. */
 export const TRIAGE_UNDO_DELAY = 5_000;
+
+/** Scoring status poll interval while work is pending (unscored/queued/scoring > 0). */
+export const SCORING_STATUS_POLL_ACTIVE = 3_000;
+
+/** Scoring status poll interval while idle, to catch background-refresh-enqueued work. */
+export const SCORING_STATUS_POLL_IDLE = 10_000;

--- a/frontend/src/lib/queryKeys.ts
+++ b/frontend/src/lib/queryKeys.ts
@@ -44,4 +44,10 @@ export const queryKeys = {
       ["categories", "list", needsTriage ?? "any"] as const,
     triageCount: ["categories", "triage-count"] as const,
   },
+  preferences: {
+    detail: ["preferences"] as const,
+  },
+  scoring: {
+    status: ["scoring", "status"] as const,
+  },
 };

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -238,3 +238,34 @@ export interface AutoGroupApplyResponse {
   groups_applied: number;
   categories_moved: number;
 }
+
+/** Mirrors backend `PreferencesResponse` (schemas.py). */
+export interface Preferences {
+  interests: string;
+  anti_interests: string;
+  feed_refresh_interval: number;
+  updated_at: string;
+}
+
+/** Mirrors backend `PreferencesUpdate` (schemas.py) — body for `PUT /api/preferences`, any subset. */
+export interface PreferencesUpdate {
+  interests?: string;
+  anti_interests?: string;
+  feed_refresh_interval?: number;
+}
+
+/** Mirrors backend `GET /api/scoring/status` response. Only the top-level scoring_state counts and `phase` are typed precisely — we read those now. Everything else is loosely typed. */
+export interface ScoringStatus {
+  unscored: number;
+  queued: number;
+  scoring: number;
+  scored: number;
+  failed: number;
+  blocked: number;
+  phase: string;
+  categorization?: unknown;
+  scoring_worker?: unknown;
+  scoring_ready?: boolean;
+  rate_limit_retry_after?: number | null;
+  [key: string]: unknown;
+}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,8 +1,16 @@
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
+import type { ScoringStatus } from "./types";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
+}
+
+// Pending = the three non-terminal scoring_state counts. Deliberately INCLUDES re-scoring articles (which have an old composite_score), so it diverges from the backend's scoring_pending_condition() which excludes them — editing interests re-queues scored articles and the chip must reflect that drain.
+export function scoringPendingCount(status: ScoringStatus | undefined): number {
+  return (
+    (status?.unscored ?? 0) + (status?.queued ?? 0) + (status?.scoring ?? 0)
+  );
 }
 
 /**

--- a/frontend/src/test/mocks/handlers/index.ts
+++ b/frontend/src/test/mocks/handlers/index.ts
@@ -1,9 +1,13 @@
 import { articleHandlers } from "./articles";
 import { categoryHandlers } from "./categories";
 import { feedHandlers } from "./feeds";
+import { preferenceHandlers } from "./preferences";
+import { scoringHandlers } from "./scoring";
 
 export const handlers = [
   ...feedHandlers,
   ...articleHandlers,
   ...categoryHandlers,
+  ...preferenceHandlers,
+  ...scoringHandlers,
 ];

--- a/frontend/src/test/mocks/handlers/preferences.ts
+++ b/frontend/src/test/mocks/handlers/preferences.ts
@@ -1,0 +1,26 @@
+import { http, HttpResponse } from "msw";
+import type { Preferences, PreferencesUpdate } from "@/lib/types";
+
+/** Fixture matching the backend `PreferencesResponse` shape exactly. */
+export const mockPreferences: Preferences = {
+  interests: "AI, distributed systems",
+  anti_interests: "celebrity gossip",
+  feed_refresh_interval: 1800,
+  updated_at: "2026-01-01T00:00:00",
+};
+
+export const preferenceHandlers = [
+  http.get("/api/preferences", () => HttpResponse.json(mockPreferences)),
+
+  http.put("/api/preferences", async ({ request }) => {
+    const body = (await request.json()) as PreferencesUpdate;
+    // Backend bumps updated_at on every PUT (preferences.py) — mirror that so
+    // the interests form's remount-reset behaves as it does in production.
+    const merged: Preferences = {
+      ...mockPreferences,
+      ...body,
+      updated_at: new Date().toISOString(),
+    };
+    return HttpResponse.json(merged);
+  }),
+];

--- a/frontend/src/test/mocks/handlers/scoring.ts
+++ b/frontend/src/test/mocks/handlers/scoring.ts
@@ -1,0 +1,17 @@
+import { http, HttpResponse } from "msw";
+import type { ScoringStatus } from "@/lib/types";
+
+/** Fixture matching `GET /api/scoring/status`. IDLE by default (all counts 0) so tests that don't care about scoring state aren't affected by the chip's polling query. */
+export const mockScoringStatus: ScoringStatus = {
+  unscored: 0,
+  queued: 0,
+  scoring: 0,
+  scored: 0,
+  failed: 0,
+  blocked: 0,
+  phase: "idle",
+};
+
+export const scoringHandlers = [
+  http.get("/api/scoring/status", () => HttpResponse.json(mockScoringStatus)),
+];


### PR DESCRIPTION
# Settings UI: interests editor + scoring-progress chip

## What is this PR about?

Adds the settings surface for LLM scoring: a page to edit your interests / anti-interests prose, and an ambient sidebar indicator showing how many articles are still being processed.

## Why is this change needed?

Scoring relevance is steered by free-text interests, but there was no way to edit them (the page was a placeholder). And when a batch is being scored, there was no signal that work is in flight — closes the last two settings gaps for #88 (stories 15 and 19).

## How is this change implemented?

- New `/settings/interests` page: two prose fields with an explicit, dirty-gated **Save** (saving triggers a re-score, so autosave would be wrong), plus a success toast.
- New sidebar chip "Processing N articles" above the Settings button — shows the count still queued/scoring, hidden when idle.
- Data layer only on the frontend: preferences + scoring-status hooks with adaptive polling (fast while working, slow while idle). No backend changes.
- Domain docs: added **Interests** / **Anti-interests** to `CONTEXT.md`.
- Tests: MSW round-trip for the interests save + chip count/idle derivation.

## How to test this change?

1. Open **Settings → Interests**. Type something into both boxes and click **Save** — a "Interests saved" confirmation appears.
2. Watch the sidebar (above the Settings button): shortly after saving, a "Processing N articles" indicator appears with a pulsing dot while the re-score runs, then disappears when it finishes.
3. On a phone-width screen, open the sidebar and confirm the same indicator and that the Interests page is comfortable to use.

## Notes

- Reviewer focus: the interests form resets via remount keyed on `updated_at`, and the save writes the PUT response straight to cache (so the reset doesn't depend on a follow-up refetch).
- The chip's "pending" count deliberately includes re-scoring articles — see the code comment on `scoringPendingCount`.
- Rate-limit / failure surfacing for scoring is intentionally out of scope (deferred to future toasts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
