### PR TITLE
Feedback capture — mutable rating + append-only event log (#101)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -49,7 +49,7 @@ The explicit feedback signal: a single thumbs up or down on an article, availabl
 _Avoid_: stars, score (that's the LLM's number)
 
 **Feedback event**:
-An append-only record of a fact about user behavior (opened, marked read, rated, rescued), with timestamp. Events record facts only; interpreting them into preference signals is the learning layer's job.
+An append-only record of a fact about user behavior, with timestamp. Three types are captured today — rated, marked read, rescued — each emitted on a genuine state transition. `opened` is a reserved-but-unemitted type (deferred); impressions are deliberately not captured (see `docs/adr/0013`). Events record facts only; interpreting them into preference signals is the learning layer's job.
 _Avoid_: engagement metric, analytics
 
 **Rescue**:

--- a/backend/alembic/versions/b60d6250cb10_add_mark_read_dwell_seconds.py
+++ b/backend/alembic/versions/b60d6250cb10_add_mark_read_dwell_seconds.py
@@ -1,0 +1,40 @@
+"""add mark_read_dwell_seconds to user_preferences
+
+Revision ID: b60d6250cb10
+Revises: d232d838dd4b
+Create Date: 2026-07-07 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b60d6250cb10"
+down_revision: str | Sequence[str] | None = "d232d838dd4b"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # server_default="5" populates the existing single row; the ORM default
+    # (Field(default=5)) covers rows inserted from Python.
+    with op.batch_alter_table("user_preferences", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "mark_read_dwell_seconds",
+                sa.Integer(),
+                nullable=False,
+                server_default="5",
+            )
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("user_preferences", schema=None) as batch_op:
+        batch_op.drop_column("mark_read_dwell_seconds")

--- a/backend/src/backend/models.py
+++ b/backend/src/backend/models.py
@@ -245,3 +245,6 @@ class UserPreferences(SQLModel, table=True):
 
     # Scheduler configuration
     feed_refresh_interval: int = Field(default=1800)  # seconds
+
+    # Reader dwell threshold gating the marked_read auto-mark (seconds)
+    mark_read_dwell_seconds: int = Field(default=5)

--- a/backend/src/backend/routers/articles.py
+++ b/backend/src/backend/routers/articles.py
@@ -17,7 +17,7 @@ from backend.deps import (
     unread_condition,
     visible_condition,
 )
-from backend.models import Article, Category, Feed
+from backend.models import Article, Category, Feed, FeedbackEvent
 from backend.schemas import (
     ArticleCategoryEmbed,
     ArticleCountsResponse,
@@ -25,6 +25,7 @@ from backend.schemas import (
     ArticleListResponse,
     ArticleResponse,
     ArticleUpdate,
+    RatingUpdate,
 )
 
 router = APIRouter(prefix="/api/articles", tags=["articles"])
@@ -91,6 +92,7 @@ def _article_to_response(article: Article) -> ArticleResponse:
         summary=article.summary,
         content=article.content,
         is_read=article.is_read,
+        rating=article.rating,
         categories=_build_category_embeds(article),
         interest_score=article.interest_score,
         quality_score=article.quality_score,
@@ -114,6 +116,7 @@ def _article_to_list_item(article: Article, feed_title: str) -> ArticleListItem:
         author=article.author,
         published_at=article.published_at,
         is_read=article.is_read,
+        rating=article.rating,
         categories=_build_category_embeds(article),
         interest_score=article.interest_score,
         quality_score=article.quality_score,
@@ -300,6 +303,9 @@ def rescue_article(article_id: int, session: Session = Depends(get_session)):
         article.interest_score = None
         article.quality_score = None
         article.composite_score = None
+        session.add(
+            FeedbackEvent(article_id=article_id, event_type="rescued", value=None)
+        )
         categorization_worker.enqueue_single_for_rescoring(
             session, article, score_only=True
         )
@@ -367,9 +373,48 @@ def update_article(
     if not article:
         raise HTTPException(status_code=404, detail="Article not found")
 
+    # Log a marked_read fact only on a genuine false->true transition.
+    if not article.is_read and update.is_read:
+        session.add(
+            FeedbackEvent(article_id=article_id, event_type="marked_read", value=None)
+        )
+
     article.is_read = update.is_read
     session.add(article)
     session.commit()
     session.refresh(article)
+
+    return _article_to_response(article)
+
+
+@router.put("/{article_id}/rating", response_model=ArticleResponse)
+def update_rating(
+    article_id: int,
+    update: RatingUpdate,
+    session: Session = Depends(get_session),
+):
+    """Set the thumbs rating (+1/-1/null), appending a rated fact on change.
+
+    The rating is a mutable projection; every genuine change also appends an
+    append-only FeedbackEvent (a clear logs value=NULL, distinct from "never
+    rated"). A no-op same-value write appends nothing.
+    """
+    article = session.exec(
+        select(Article)
+        .where(Article.id == article_id)
+        .options(selectinload(Article.categories_rel).joinedload(Category.parent))  # pyright: ignore[reportArgumentType]
+    ).first()
+
+    if not article:
+        raise HTTPException(status_code=404, detail="Article not found")
+
+    if update.value != article.rating:
+        article.rating = update.value
+        session.add(article)
+        session.add(
+            FeedbackEvent(article_id=article_id, event_type="rated", value=update.value)
+        )
+        session.commit()
+        session.refresh(article)
 
     return _article_to_response(article)

--- a/backend/src/backend/routers/preferences.py
+++ b/backend/src/backend/routers/preferences.py
@@ -12,6 +12,8 @@ router = APIRouter(prefix="/api/preferences", tags=["preferences"])
 
 MIN_REFRESH_INTERVAL = 60  # 1 minute
 MAX_REFRESH_INTERVAL = 14400  # 4 hours
+MIN_DWELL_SECONDS = 1
+MAX_DWELL_SECONDS = 60
 
 
 @router.get("", response_model=PreferencesResponse)
@@ -25,6 +27,7 @@ def get_preferences(
         interests=preferences.interests,
         anti_interests=preferences.anti_interests,
         feed_refresh_interval=preferences.feed_refresh_interval,
+        mark_read_dwell_seconds=preferences.mark_read_dwell_seconds,
         updated_at=preferences.updated_at,
     )
 
@@ -57,6 +60,16 @@ async def update_preferences(
             )
         preferences.feed_refresh_interval = update.feed_refresh_interval
 
+    if update.mark_read_dwell_seconds is not None:
+        if not (
+            MIN_DWELL_SECONDS <= update.mark_read_dwell_seconds <= MAX_DWELL_SECONDS
+        ):
+            raise HTTPException(
+                status_code=422,
+                detail=f"mark_read_dwell_seconds must be between {MIN_DWELL_SECONDS} and {MAX_DWELL_SECONDS} seconds",
+            )
+        preferences.mark_read_dwell_seconds = update.mark_read_dwell_seconds
+
     preferences.updated_at = datetime.now()
 
     session.add(preferences)
@@ -77,5 +90,6 @@ async def update_preferences(
         interests=preferences.interests,
         anti_interests=preferences.anti_interests,
         feed_refresh_interval=preferences.feed_refresh_interval,
+        mark_read_dwell_seconds=preferences.mark_read_dwell_seconds,
         updated_at=preferences.updated_at,
     )

--- a/backend/src/backend/schemas.py
+++ b/backend/src/backend/schemas.py
@@ -25,6 +25,18 @@ class ArticleUpdate(BaseModel):
     is_read: bool
 
 
+class RatingUpdate(BaseModel):
+    """Thumbs rating: +1 / -1, or None to clear. Any other int is a 422."""
+
+    value: int | None
+
+    @model_validator(mode="after")
+    def value_in_vocabulary(self):
+        if self.value is not None and self.value not in (1, -1):
+            raise ValueError("value must be 1, -1, or null")
+        return self
+
+
 class ArticleCategoryEmbed(BaseModel):
     """Category embedded in article response."""
 
@@ -47,6 +59,7 @@ class ArticleListItem(BaseModel):
     author: str | None
     published_at: datetime | None
     is_read: bool
+    rating: int | None
     categories: list[ArticleCategoryEmbed] | None
     interest_score: int | None
     quality_score: int | None
@@ -86,6 +99,7 @@ class ArticleResponse(BaseModel):
     summary: str | None
     content: str | None
     is_read: bool
+    rating: int | None
     categories: list[ArticleCategoryEmbed] | None
     interest_score: int | None
     quality_score: int | None
@@ -161,6 +175,7 @@ class PreferencesResponse(BaseModel):
     interests: str
     anti_interests: str
     feed_refresh_interval: int
+    mark_read_dwell_seconds: int
     updated_at: datetime
 
 
@@ -168,6 +183,7 @@ class PreferencesUpdate(BaseModel):
     interests: str | None = None
     anti_interests: str | None = None
     feed_refresh_interval: int | None = None
+    mark_read_dwell_seconds: int | None = None
 
 
 # --- Categories ---

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -1,0 +1,272 @@
+"""API-seam tests for issue #101: feedback capture.
+
+Covers the rating projection + event log (PUT /api/articles/{id}/rating),
+the marked_read transition event in PATCH, and the rescued transition event.
+Every rating change writes both the mutable projection and an append-only
+FeedbackEvent; behavioral events are emitted only on genuine state transitions.
+"""
+
+from datetime import datetime
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from backend.models import Article, FeedbackEvent
+
+
+def _events(session: Session, article_id: int, event_type: str) -> list[FeedbackEvent]:
+    return list(
+        session.exec(
+            select(FeedbackEvent)
+            .where(FeedbackEvent.article_id == article_id)
+            .where(FeedbackEvent.event_type == event_type)
+            .order_by(FeedbackEvent.id)  # pyright: ignore[reportArgumentType]
+        ).all()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rating: projection + rated event log
+# ---------------------------------------------------------------------------
+
+
+def test_rating_set_positive_sets_column_and_logs_one_event(
+    test_client: TestClient, make_feed, make_article, test_session: Session
+):
+    feed = make_feed()
+    article = make_article(feed.id)
+
+    response = test_client.put(f"/api/articles/{article.id}/rating", json={"value": 1})
+
+    assert response.status_code == 200
+    assert response.json()["rating"] == 1
+
+    test_session.expire_all()
+    updated = test_session.get(Article, article.id)
+    assert updated.rating == 1
+
+    events = _events(test_session, article.id, "rated")
+    assert len(events) == 1
+    assert events[0].value == 1
+
+
+def test_rating_change_logs_second_event(
+    test_client: TestClient, make_feed, make_article, test_session: Session
+):
+    feed = make_feed()
+    article = make_article(feed.id)
+
+    test_client.put(f"/api/articles/{article.id}/rating", json={"value": 1})
+    response = test_client.put(f"/api/articles/{article.id}/rating", json={"value": -1})
+
+    assert response.status_code == 200
+    assert response.json()["rating"] == -1
+
+    test_session.expire_all()
+    updated = test_session.get(Article, article.id)
+    assert updated.rating == -1
+
+    events = _events(test_session, article.id, "rated")
+    assert [e.value for e in events] == [1, -1]
+
+
+def test_rating_clear_logs_null_event_and_nulls_column(
+    test_client: TestClient, make_feed, make_article, test_session: Session
+):
+    feed = make_feed()
+    article = make_article(feed.id)
+
+    test_client.put(f"/api/articles/{article.id}/rating", json={"value": 1})
+    response = test_client.put(
+        f"/api/articles/{article.id}/rating", json={"value": None}
+    )
+
+    assert response.status_code == 200
+    assert response.json()["rating"] is None
+
+    test_session.expire_all()
+    updated = test_session.get(Article, article.id)
+    assert updated.rating is None
+
+    events = _events(test_session, article.id, "rated")
+    # first the +1, then the clear (value NULL) — a distinct signal from "never rated".
+    assert [e.value for e in events] == [1, None]
+
+
+def test_rating_no_op_same_value_logs_nothing(
+    test_client: TestClient, make_feed, make_article, test_session: Session
+):
+    feed = make_feed()
+    article = make_article(feed.id)
+
+    test_client.put(f"/api/articles/{article.id}/rating", json={"value": 1})
+    response = test_client.put(f"/api/articles/{article.id}/rating", json={"value": 1})
+
+    assert response.status_code == 200
+    assert response.json()["rating"] == 1
+
+    test_session.expire_all()
+    events = _events(test_session, article.id, "rated")
+    assert len(events) == 1
+
+
+def test_rating_no_op_null_on_unrated_logs_nothing(
+    test_client: TestClient, make_feed, make_article, test_session: Session
+):
+    feed = make_feed()
+    article = make_article(feed.id)
+
+    response = test_client.put(
+        f"/api/articles/{article.id}/rating", json={"value": None}
+    )
+
+    assert response.status_code == 200
+    assert response.json()["rating"] is None
+
+    test_session.expire_all()
+    assert _events(test_session, article.id, "rated") == []
+
+
+def test_rating_invalid_value_422(test_client: TestClient, make_feed, make_article):
+    feed = make_feed()
+    article = make_article(feed.id)
+
+    response = test_client.put(f"/api/articles/{article.id}/rating", json={"value": 2})
+    assert response.status_code == 422
+
+
+def test_rating_unknown_article_404(test_client: TestClient):
+    response = test_client.put("/api/articles/999999/rating", json={"value": 1})
+    assert response.status_code == 404
+
+
+def test_rating_present_in_detail_and_list(
+    test_client: TestClient, make_feed, make_article
+):
+    feed = make_feed()
+    article = make_article(feed.id)
+
+    test_client.put(f"/api/articles/{article.id}/rating", json={"value": -1})
+
+    detail = test_client.get(f"/api/articles/{article.id}").json()
+    assert detail["rating"] == -1
+
+    listing = test_client.get("/api/articles").json()
+    item = next(i for i in listing["items"] if i["id"] == article.id)
+    assert item["rating"] == -1
+
+
+# ---------------------------------------------------------------------------
+# marked_read: false->true transition only
+# ---------------------------------------------------------------------------
+
+
+def test_mark_read_transition_logs_event(
+    test_client: TestClient, make_feed, make_article, test_session: Session
+):
+    feed = make_feed()
+    article = make_article(feed.id, is_read=False)
+
+    response = test_client.patch(f"/api/articles/{article.id}", json={"is_read": True})
+    assert response.status_code == 200
+
+    test_session.expire_all()
+    assert len(_events(test_session, article.id, "marked_read")) == 1
+
+
+def test_re_patch_already_read_logs_nothing(
+    test_client: TestClient, make_feed, make_article, test_session: Session
+):
+    feed = make_feed()
+    article = make_article(feed.id, is_read=False)
+
+    test_client.patch(f"/api/articles/{article.id}", json={"is_read": True})
+    test_client.patch(f"/api/articles/{article.id}", json={"is_read": True})
+
+    test_session.expire_all()
+    assert len(_events(test_session, article.id, "marked_read")) == 1
+
+
+def test_unread_transition_logs_nothing(
+    test_client: TestClient, make_feed, make_article, test_session: Session
+):
+    feed = make_feed()
+    article = make_article(feed.id, is_read=True)
+
+    test_client.patch(f"/api/articles/{article.id}", json={"is_read": False})
+
+    test_session.expire_all()
+    assert _events(test_session, article.id, "marked_read") == []
+
+
+def test_mark_all_read_logs_no_marked_read_events(
+    test_client: TestClient, make_feed, make_article, test_session: Session
+):
+    feed = make_feed()
+    a1 = make_article(feed.id, is_read=False)
+    a2 = make_article(feed.id, is_read=False)
+    a3 = make_article(feed.id, is_read=False)
+
+    response = test_client.post("/api/articles/mark-all-read")
+    assert response.status_code == 200
+
+    test_session.expire_all()
+    all_events = list(
+        test_session.exec(
+            select(FeedbackEvent).where(FeedbackEvent.event_type == "marked_read")
+        ).all()
+    )
+    assert all_events == []
+    # sanity: the articles were actually marked read
+    for a in (a1, a2, a3):
+        assert test_session.get(Article, a.id).is_read is True
+
+
+# ---------------------------------------------------------------------------
+# rescued: block->visible transition only (branch 1)
+# ---------------------------------------------------------------------------
+
+
+def test_rescue_blocked_logs_event(
+    test_client: TestClient, make_feed, make_article, test_session: Session
+):
+    feed = make_feed()
+    article = make_article(feed.id, scoring_state="blocked", composite_score=0.0)
+
+    response = test_client.post(f"/api/articles/{article.id}/rescue")
+    assert response.status_code == 200
+
+    test_session.expire_all()
+    assert len(_events(test_session, article.id, "rescued")) == 1
+
+
+def test_double_rescue_logs_one_event(
+    test_client: TestClient, make_feed, make_article, test_session: Session
+):
+    feed = make_feed()
+    article = make_article(feed.id, scoring_state="blocked", composite_score=0.0)
+
+    test_client.post(f"/api/articles/{article.id}/rescue")
+    test_client.post(f"/api/articles/{article.id}/rescue")
+
+    test_session.expire_all()
+    assert len(_events(test_session, article.id, "rescued")) == 1
+
+
+def test_rescue_failed_rescored_logs_no_event(
+    test_client: TestClient, make_feed, make_article, test_session: Session
+):
+    feed = make_feed()
+    article = make_article(
+        feed.id,
+        scoring_state="failed",
+        categorization_state="categorized",
+        rescued_at=datetime.now(),
+        scoring_attempts=3,
+        composite_score=None,
+    )
+
+    test_client.post(f"/api/articles/{article.id}/rescue")
+
+    test_session.expire_all()
+    assert _events(test_session, article.id, "rescued") == []

--- a/backend/tests/test_preferences_dwell.py
+++ b/backend/tests/test_preferences_dwell.py
@@ -1,0 +1,48 @@
+"""API-seam tests for the mark_read_dwell_seconds preference (issue #101).
+
+The dwell threshold gating the marked_read auto-mark is runtime-tunable in
+General settings. Bounds are 1..60s; changing it must NOT trigger rescoring
+(unlike interests/anti_interests).
+"""
+
+from fastapi.testclient import TestClient
+
+
+def test_dwell_default_exposed_in_get(test_client: TestClient):
+    prefs = test_client.get("/api/preferences").json()
+    assert prefs["mark_read_dwell_seconds"] == 5
+
+
+def test_dwell_update_persists(test_client: TestClient):
+    response = test_client.put("/api/preferences", json={"mark_read_dwell_seconds": 12})
+    assert response.status_code == 200
+    assert response.json()["mark_read_dwell_seconds"] == 12
+
+    assert test_client.get("/api/preferences").json()["mark_read_dwell_seconds"] == 12
+
+
+def test_dwell_below_min_rejected(test_client: TestClient):
+    response = test_client.put("/api/preferences", json={"mark_read_dwell_seconds": 0})
+    assert response.status_code == 422
+
+
+def test_dwell_above_max_rejected(test_client: TestClient):
+    response = test_client.put("/api/preferences", json={"mark_read_dwell_seconds": 61})
+    assert response.status_code == 422
+
+
+def test_dwell_change_does_not_trigger_rescoring(test_client: TestClient, monkeypatch):
+    called = False
+
+    def _spy(*args, **kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(
+        "backend.scheduler.categorization_worker.enqueue_recent_for_rescoring",
+        _spy,
+    )
+
+    response = test_client.put("/api/preferences", json={"mark_read_dwell_seconds": 20})
+    assert response.status_code == 200
+    assert called is False

--- a/docs/adr/0013-feedback-event-log.md
+++ b/docs/adr/0013-feedback-event-log.md
@@ -1,0 +1,33 @@
+# Feedback capture: mutable rating projection + append-only event log
+
+Feedback is captured in two coupled shapes. The **rating** is a mutable thumbs value on the article (`+1` / `-1` / `NULL`), the current-state projection the UI reads and writes. The **feedback event log** (`feedback_events`) is an append-only ledger of behavioral facts with timestamps, write-only in v2 and consumed only by the future learning layer (#88 out-of-scope; tracked separately). Every rating change writes both: the projection is overwritten, a fact is appended.
+
+Three event types are captured in v2, all emitted on genuine state transitions:
+
+- **`rated`** (`value` = `+1` / `-1` / `NULL`) — every rating change through `PUT /api/articles/{id}/rating`, guarded so a no-op same-value write emits nothing. A clear logs `rated` with `value=NULL` — distinct signal from "never rated", not a silent wipe.
+- **`marked_read`** (`value NULL`) — a single-article `is_read` `false→true` transition (reader dwell auto-mark or manual per-row toggle, both via `PATCH /api/articles/{id}`). Mark-all-read and un-read emit nothing.
+- **`rescued`** (`value NULL`) — the block→visible transition only (`rescue_article` branch 1). Idempotent retries and no-op replays emit nothing.
+
+`opened` remains in the `FEEDBACK_EVENT_TYPES` allow-list but is **not emitted** in v2 (see Deferrals) — reserving it means the learning layer can start emitting it later with no migration.
+
+## Why
+
+- **Projection + log split**: the UI needs a cheap current-value read ("what did I rate this?"); the learning layer needs the full history ("how did preferences evolve?"). A mutable column answers the first, an append-only log the second. Netflix's stars→thumbs move validated binary-with-history as more honest and more abundant than graded self-reports; a clear is logged as a fact because "I changed my mind" differs from "never engaged."
+- **Emit on transition, never on replay**: endpoints are idempotent for safety, but the log records *decisions*. A rescue decision happens once (the block→visible edge); logging retries would double-count one preference signal. The same rule excludes mark-all-read — bulk backlog-clearing is the opposite of engagement and would inject false "read" positives.
+- **Append-only enforced app-layer only**: no update/delete route exists; the ORM only ever `INSERT`s events. A DB-level trigger was considered (the table already enforces its value/type invariants at the DB) but deferred as belt-and-suspenders unjustified for a single-user, self-hosted app where every code path is ours.
+- **Rating is inert in v2**: it does not affect scoring, filtering, counts, or ordering — pure capture for a consumer that does not exist yet. This is a deliberate scope boundary against "thumbs-down nudges the score" leaking in early.
+
+## Consequences
+
+- No migration for the feedback schema (it ships in the v2 baseline). The only new column is `mark_read_dwell_seconds` on `UserPreferences` — the dwell threshold gating `marked_read` quality, made runtime-tunable (General settings) rather than hardcoded.
+- The event log grows monotonically; retention is not addressed (thousands of rows/year is trivial for SQLite).
+- Consumer guidance for the learning layer: **order by `id`, not `created_at`** (wall-clock skew); **absence of an event is not a negative** (low-confidence at most); expect **rating sparsity** (most articles never rated); beware the **self-reinforcing filter bubble** (blocked items get no feedback, so the scorer can't learn it was wrong to hide them); feedback is only interpretable relative to the interest-profile version in effect when it was given.
+
+## Deferrals
+
+Deliberately not captured in v2, each addable later without reworking the schema. Tracked in the v2.1 learning-layer issue.
+
+- **Impressions + display position** — the strongest deferral. Without logging what was *shown but not opened*, the learning layer cannot distinguish "rejected" from "never seen" (selection/exposure bias, the most damaging pitfall in log-fed ranking; position bias confounds `opened`). Deferred for volume (impressions dwarf interactions) and category (system-presentation facts, not user behavior); the near-term few-shot path needs positives, not impression-derived negatives. Must be reckoned with when the learning layer is built.
+- **`opened`** — descoped from #101 AC #2; lowest-value signal and the only one needing bespoke machinery. Note: the `opened`+`marked_read` pair would have given a facts-only engagement-depth signal (opened-and-bounced vs opened-and-stayed) not confounded by position.
+- **Blocked-score-at-rescue** — `rescue_article` NULLs the composite/interest/quality scores before re-queuing, so "what score did the user override?" is irreversibly lost. Recoverable only by snapshotting into a payload before nulling (needs a `payload JSON` column), judged not worth it for the rare rescue event.
+- **DB-level append-only trigger**, **event schema-versioning**, **thumbs reason-codes** (contradicts the binary-by-design rating) — all considered, all YAGNI for now.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,8 +5,11 @@ WORKDIR /app
 # Copy package files
 COPY package.json bun.lock ./
 
-# Install dependencies (frozen lockfile for reproducible builds)
-RUN bun install --frozen-lockfile
+# Install dependencies (frozen lockfile for reproducible builds).
+# --ignore-scripts: the `prepare` lifecycle script installs git hooks via
+# ../scripts/install-hooks.sh, which is outside this build context (frontend/
+# only) and irrelevant to the image — running it would fail the build.
+RUN bun install --frozen-lockfile --ignore-scripts
 
 # Copy application code
 COPY . .

--- a/frontend/src/app/settings/general/page.tsx
+++ b/frontend/src/app/settings/general/page.tsx
@@ -1,10 +1,5 @@
-import { SettingsPlaceholder } from "@/components/settings-placeholder";
+import { GeneralSettings } from "@/components/general-settings";
 
 export default function GeneralSettingsPage() {
-  return (
-    <SettingsPlaceholder
-      title="General"
-      blurb="Theme, refresh cadence, and other app-wide settings."
-    />
-  );
+  return <GeneralSettings />;
 }

--- a/frontend/src/components/article-list.test.tsx
+++ b/frontend/src/components/article-list.test.tsx
@@ -101,6 +101,24 @@ describe("ArticleList", () => {
     );
   });
 
+  it("shows the rating control per row, but hides it while the reader is open", async () => {
+    const { setReaderOpen } = renderList();
+
+    // Reader closed: each row exposes a thumbs-up rating toggle.
+    await screen.findByText("Article 2");
+    expect(
+      screen.getAllByRole("radio", { name: "Thumbs up" }).length,
+    ).toBeGreaterThan(0);
+
+    // Reader open: the reader owns the rating control, so the list drops it.
+    setReaderOpen(true);
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("radio", { name: "Thumbs up" }),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
   it("marks a row read via the dot toggle and dims the row", async () => {
     const user = userEvent.setup();
     let patchedRead: boolean | null = null;

--- a/frontend/src/components/article-list.tsx
+++ b/frontend/src/components/article-list.tsx
@@ -126,14 +126,18 @@ function ArticleRow({
           />
         ))}
         {/* Rating toggles live inside the clickable row — stop propagation so a
-            thumbs tap rates without also opening the reader. */}
-        <div
-          className="ml-auto"
-          onClick={(e) => e.stopPropagation()}
-          role="presentation"
-        >
-          <RatingControl articleId={article.id} rating={article.rating} />
-        </div>
+            thumbs tap rates without also opening the reader. Hidden while the
+            reader is open (dense): the reader owns the rating control then, so
+            the list shouldn't duplicate it. */}
+        {!dense && (
+          <div
+            className="ml-auto"
+            onClick={(e) => e.stopPropagation()}
+            role="presentation"
+          >
+            <RatingControl articleId={article.id} rating={article.rating} />
+          </div>
+        )}
       </div>
     </article>
   );

--- a/frontend/src/components/article-list.tsx
+++ b/frontend/src/components/article-list.tsx
@@ -5,6 +5,7 @@ import { useMemo } from "react";
 
 import { CategoryChip, ReadDot, ScoreChip } from "@/components/article-badges";
 import { LoadMoreButton } from "@/components/load-more-button";
+import { RatingControl } from "@/components/rating-control";
 import { ErrorState } from "@/components/list-states";
 import {
   Empty,
@@ -113,20 +114,27 @@ function ArticleRow({
         )}
       </div>
 
-      {(article.composite_score !== null || categories.length > 0) && (
-        <div className="mt-2 flex flex-wrap items-center gap-1.5">
-          {article.composite_score !== null && (
-            <ScoreChip score={article.composite_score} />
-          )}
-          {categories.map((category) => (
-            <CategoryChip
-              key={category.id}
-              label={category.display_name}
-              needsTriage={category.needs_triage}
-            />
-          ))}
+      <div className="mt-2 flex flex-wrap items-center gap-1.5">
+        {article.composite_score !== null && (
+          <ScoreChip score={article.composite_score} />
+        )}
+        {categories.map((category) => (
+          <CategoryChip
+            key={category.id}
+            label={category.display_name}
+            needsTriage={category.needs_triage}
+          />
+        ))}
+        {/* Rating toggles live inside the clickable row — stop propagation so a
+            thumbs tap rates without also opening the reader. */}
+        <div
+          className="ml-auto"
+          onClick={(e) => e.stopPropagation()}
+          role="presentation"
+        >
+          <RatingControl articleId={article.id} rating={article.rating} />
         </div>
-      )}
+      </div>
     </article>
   );
 }

--- a/frontend/src/components/article-reader.test.tsx
+++ b/frontend/src/components/article-reader.test.tsx
@@ -42,6 +42,7 @@ function listItem(overrides: Partial<ArticleListItem> = {}): ArticleListItem {
     scoring_state: "scored",
     scored_at: null,
     re_evaluating: false,
+    rating: null,
     ...overrides,
   };
 }

--- a/frontend/src/components/article-reader.tsx
+++ b/frontend/src/components/article-reader.tsx
@@ -9,31 +9,44 @@ import {
   ReadDot,
   ReaderScores,
 } from "@/components/article-badges";
+import { RatingControl } from "@/components/rating-control";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useArticle } from "@/hooks/useArticle";
 import { useMarkRead } from "@/hooks/useMarkRead";
+import { usePreferences } from "@/hooks/usePreferences";
 import { formatAge } from "@/lib/utils";
 import type { ArticleListItem } from "@/lib/types";
 
-/** Dwell threshold before auto-marking an opened article read — issue #94 decision. */
-const MARK_READ_DWELL_MS = 3000;
+/** Fallback dwell threshold (seconds) when the preference hasn't loaded — issue #94 default. */
+const DEFAULT_DWELL_SECONDS = 5;
 
 interface ArticleReaderProps {
   /** The list item that was opened — supplies feed/meta/score fields immediately. */
   article: ArticleListItem;
   onClose: () => void;
-  /** Overridable only for tests; production uses the #94-decided threshold. */
+  /** Test-only override; production reads the dwell from preferences (prop wins if provided). */
   dwellMs?: number;
 }
 
 export function ArticleReader({
   article,
   onClose,
-  dwellMs = MARK_READ_DWELL_MS,
+  dwellMs,
 }: ArticleReaderProps) {
   const detailQuery = useArticle(article.id);
   const markRead = useMarkRead();
+  const { data: preferences } = usePreferences();
+
+  // The prop is a test-only override; otherwise the configurable preference
+  // (seconds → ms) drives the dwell, falling back to the #94 default.
+  const resolvedDwellMs =
+    dwellMs ??
+    (preferences?.mark_read_dwell_seconds ?? DEFAULT_DWELL_SECONDS) * 1000;
+
+  // Live rating tracks the cached detail (the rate mutation patches it),
+  // falling back to the list item until the detail query resolves.
+  const rating = detailQuery.data?.rating ?? article.rating;
 
   // Live read status tracks the cached detail (the mark-read mutation flips it),
   // falling back to the list item until the detail query resolves.
@@ -70,9 +83,9 @@ export function ArticleReader({
     if (!wasUnreadAtOpen || !contentLoaded) return;
     const timer = setTimeout(() => {
       markMutate({ id: articleId, isRead: true });
-    }, dwellMs);
+    }, resolvedDwellMs);
     return () => clearTimeout(timer);
-  }, [articleId, wasUnreadAtOpen, contentLoaded, dwellMs, markMutate]);
+  }, [articleId, wasUnreadAtOpen, contentLoaded, resolvedDwellMs, markMutate]);
 
   return (
     <div className="bg-background animate-in fade-in md:slide-in-from-right fixed inset-0 z-40 flex flex-col duration-200 md:static md:z-auto md:min-w-0 md:flex-1">
@@ -102,6 +115,11 @@ export function ArticleReader({
                     needsTriage={category.needs_triage}
                   />
                 ))}
+                <RatingControl
+                  articleId={article.id}
+                  rating={rating}
+                  className="ml-auto"
+                />
               </div>
 
               <h1 className="font-serif text-3xl leading-tight font-bold">

--- a/frontend/src/components/general-settings.tsx
+++ b/frontend/src/components/general-settings.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { usePreferences } from "@/hooks/usePreferences";
+import { useUpdatePreferences } from "@/hooks/useUpdatePreferences";
+import type { Preferences } from "@/lib/types";
+import { Button } from "@/components/ui/button";
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const DWELL_MIN_SECONDS = 1;
+const DWELL_MAX_SECONDS = 60;
+
+/** Form body — keyed by `updated_at` at the call site so a successful save
+ * (which bumps `updated_at` server-side) remounts it and resets the baseline. */
+function GeneralForm({ initial }: { initial: Preferences }) {
+  const [dwellSeconds, setDwellSeconds] = useState(
+    String(initial.mark_read_dwell_seconds),
+  );
+  const updatePreferences = useUpdatePreferences();
+
+  const isDirty = dwellSeconds !== String(initial.mark_read_dwell_seconds);
+
+  return (
+    <form
+      className="flex flex-col gap-5"
+      onSubmit={(event) => {
+        event.preventDefault();
+        updatePreferences.mutate(
+          { mark_read_dwell_seconds: Number(dwellSeconds) },
+          { onSuccess: () => toast.success("Settings saved") },
+        );
+      }}
+    >
+      <Field>
+        <FieldLabel htmlFor="mark-read-dwell">
+          Mark-as-read delay (seconds)
+        </FieldLabel>
+        <Input
+          id="mark-read-dwell"
+          type="number"
+          inputMode="numeric"
+          min={DWELL_MIN_SECONDS}
+          max={DWELL_MAX_SECONDS}
+          className="w-24"
+          value={dwellSeconds}
+          onChange={(event) => setDwellSeconds(event.target.value)}
+          disabled={updatePreferences.isPending}
+        />
+        <FieldDescription>
+          How long an opened article stays visible before it&apos;s
+          automatically marked read.
+        </FieldDescription>
+      </Field>
+      <Button
+        type="submit"
+        className="h-11 self-end sm:h-9"
+        disabled={!isDirty || updatePreferences.isPending}
+      >
+        {updatePreferences.isPending ? "Saving…" : "Save"}
+      </Button>
+    </form>
+  );
+}
+
+/** The General settings section — app-wide behavior tuning (currently the mark-as-read dwell). */
+export function GeneralSettings() {
+  const { data, isPending, isError } = usePreferences();
+
+  return (
+    <div className="flex flex-col gap-5">
+      <h2 className="text-lg font-semibold">General</h2>
+
+      {isPending ? (
+        <Skeleton className="h-20 w-full" />
+      ) : isError ? (
+        <p className="text-muted-foreground text-sm">
+          Couldn&apos;t load your settings. Retrying…
+        </p>
+      ) : (
+        <GeneralForm key={data.updated_at} initial={data} />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/rating-control.test.tsx
+++ b/frontend/src/components/rating-control.test.tsx
@@ -1,0 +1,111 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { RatingControl } from "@/components/rating-control";
+import { mockArticleDetail } from "@/test/mocks/handlers/articles";
+import { server } from "@/test/mocks/server";
+import { queryKeys } from "@/lib/queryKeys";
+import type { ArticleListResponse } from "@/lib/types";
+import {
+  createTestQueryClient,
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from "@/test/utils";
+
+const ARTICLE_ID = 1;
+
+/** Capture the last `PUT /api/articles/:id/rating` body across the test. */
+function stubRating() {
+  let lastBody: { value: 1 | -1 | null } | null = null;
+  server.use(
+    http.put("/api/articles/:id/rating", async ({ params, request }) => {
+      lastBody = (await request.json()) as { value: 1 | -1 | null };
+      return HttpResponse.json({
+        ...mockArticleDetail,
+        id: Number(params.id),
+        rating: lastBody.value,
+      });
+    }),
+  );
+  return () => lastBody;
+}
+
+function renderControl(rating: number | null) {
+  const queryClient = createTestQueryClient();
+  render(
+    <QueryClientProvider client={queryClient}>
+      <RatingControl articleId={ARTICLE_ID} rating={rating} />
+    </QueryClientProvider>,
+  );
+  return { queryClient };
+}
+
+describe("RatingControl", () => {
+  it("reflects the current rating as the selected toggle", () => {
+    renderControl(1);
+    expect(screen.getByRole("radio", { name: "Thumbs up" })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    expect(screen.getByRole("radio", { name: "Thumbs down" })).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
+  });
+
+  it("tapping up sends value:1", async () => {
+    const getBody = stubRating();
+    const user = userEvent.setup();
+    renderControl(null);
+
+    await user.click(screen.getByRole("radio", { name: "Thumbs up" }));
+    await waitFor(() => expect(getBody()).toEqual({ value: 1 }));
+  });
+
+  it("tapping the active up item clears (value:null)", async () => {
+    const getBody = stubRating();
+    const user = userEvent.setup();
+    renderControl(1);
+
+    await user.click(screen.getByRole("radio", { name: "Thumbs up" }));
+    await waitFor(() => expect(getBody()).toEqual({ value: null }));
+  });
+
+  it("tapping down switches (value:-1)", async () => {
+    const getBody = stubRating();
+    const user = userEvent.setup();
+    renderControl(1);
+
+    await user.click(screen.getByRole("radio", { name: "Thumbs down" }));
+    await waitFor(() => expect(getBody()).toEqual({ value: -1 }));
+  });
+
+  it("patches the article list cache with the new rating", async () => {
+    stubRating();
+    const user = userEvent.setup();
+    const { queryClient } = renderControl(null);
+
+    const listKey = queryKeys.articles.list({ type: "all" });
+    queryClient.setQueryData(listKey, {
+      pages: [
+        {
+          items: [{ ...mockArticleDetail, id: ARTICLE_ID, rating: null }],
+          has_more: false,
+        },
+      ],
+      pageParams: [0],
+    });
+
+    await user.click(screen.getByRole("radio", { name: "Thumbs up" }));
+
+    await waitFor(() => {
+      const data = queryClient.getQueryData<{
+        pages: ArticleListResponse[];
+      }>(listKey);
+      expect(data?.pages[0].items[0].rating).toBe(1);
+    });
+  });
+});

--- a/frontend/src/components/rating-control.tsx
+++ b/frontend/src/components/rating-control.tsx
@@ -19,6 +19,18 @@ function valueToRating(value: string): 1 | -1 | null {
   return null;
 }
 
+/**
+ * Prominent selected styling per thumb — a filled, colored fill instead of the
+ * base `data-[state=on]:bg-accent` (which reads as too subtle). Up = primary,
+ * down = destructive; the `hover:` variants pin the color so an active thumb
+ * doesn't revert to the outline hover state. The `data-[state=on]:` prefix
+ * matches the base variant so tailwind-merge dedupes and this wins.
+ */
+const UP_SELECTED =
+  "data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:border-primary data-[state=on]:hover:bg-primary data-[state=on]:hover:text-primary-foreground data-[state=on]:[&_svg]:fill-current";
+const DOWN_SELECTED =
+  "data-[state=on]:bg-destructive data-[state=on]:text-white data-[state=on]:border-destructive data-[state=on]:hover:bg-destructive data-[state=on]:hover:text-white data-[state=on]:[&_svg]:fill-current";
+
 interface RatingControlProps {
   articleId: number;
   /** The article's current rating projection (`1` / `-1` / `null`). */
@@ -49,10 +61,18 @@ export function RatingControl({
       }
       className={className}
     >
-      <ToggleGroupItem value="up" aria-label="Thumbs up">
+      <ToggleGroupItem
+        value="up"
+        aria-label="Thumbs up"
+        className={UP_SELECTED}
+      >
         <ThumbsUp />
       </ToggleGroupItem>
-      <ToggleGroupItem value="down" aria-label="Thumbs down">
+      <ToggleGroupItem
+        value="down"
+        aria-label="Thumbs down"
+        className={DOWN_SELECTED}
+      >
         <ThumbsDown />
       </ToggleGroupItem>
     </ToggleGroup>

--- a/frontend/src/components/rating-control.tsx
+++ b/frontend/src/components/rating-control.tsx
@@ -20,16 +20,14 @@ function valueToRating(value: string): 1 | -1 | null {
 }
 
 /**
- * Prominent selected styling per thumb — a filled, colored fill instead of the
- * base `data-[state=on]:bg-accent` (which reads as too subtle). Up = primary,
- * down = destructive; the `hover:` variants pin the color so an active thumb
- * doesn't revert to the outline hover state. The `data-[state=on]:` prefix
- * matches the base variant so tailwind-merge dedupes and this wins.
+ * Selected styling for both thumbs — the primary color on the icon and the
+ * outline, with no background fill (overriding the base
+ * `data-[state=on]:bg-accent`). The `data-[state=on]:hover:` variants pin the
+ * look so an active thumb doesn't revert to the outline hover state, and the
+ * matching `data-[state=on]:` prefix lets tailwind-merge dedupe the base away.
  */
-const UP_SELECTED =
-  "data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:border-primary data-[state=on]:hover:bg-primary data-[state=on]:hover:text-primary-foreground data-[state=on]:[&_svg]:fill-current";
-const DOWN_SELECTED =
-  "data-[state=on]:bg-destructive data-[state=on]:text-white data-[state=on]:border-destructive data-[state=on]:hover:bg-destructive data-[state=on]:hover:text-white data-[state=on]:[&_svg]:fill-current";
+const SELECTED =
+  "data-[state=on]:bg-transparent data-[state=on]:text-primary data-[state=on]:border-primary data-[state=on]:hover:bg-transparent data-[state=on]:hover:text-primary";
 
 interface RatingControlProps {
   articleId: number;
@@ -61,17 +59,13 @@ export function RatingControl({
       }
       className={className}
     >
-      <ToggleGroupItem
-        value="up"
-        aria-label="Thumbs up"
-        className={UP_SELECTED}
-      >
+      <ToggleGroupItem value="up" aria-label="Thumbs up" className={SELECTED}>
         <ThumbsUp />
       </ToggleGroupItem>
       <ToggleGroupItem
         value="down"
         aria-label="Thumbs down"
-        className={DOWN_SELECTED}
+        className={SELECTED}
       >
         <ThumbsDown />
       </ToggleGroupItem>

--- a/frontend/src/components/rating-control.tsx
+++ b/frontend/src/components/rating-control.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { ThumbsDown, ThumbsUp } from "lucide-react";
+
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { useRateArticle } from "@/hooks/useRateArticle";
+
+/** Maps the article's `rating` projection to the ToggleGroup's string value. */
+function ratingToValue(rating: number | null): "up" | "down" | "" {
+  if (rating === 1) return "up";
+  if (rating === -1) return "down";
+  return "";
+}
+
+/** Maps a ToggleGroup value back to the rating sent to the API. `""` (tap-active-to-clear) → `null`. */
+function valueToRating(value: string): 1 | -1 | null {
+  if (value === "up") return 1;
+  if (value === "down") return -1;
+  return null;
+}
+
+interface RatingControlProps {
+  articleId: number;
+  /** The article's current rating projection (`1` / `-1` / `null`). */
+  rating: number | null;
+  className?: string;
+}
+
+/**
+ * Two-item thumbs toggle. `type="single"` deselecting the active item to `""`
+ * is the clear gesture (tap-active-to-clear). Rating is inert — the mutation
+ * only patches caches, it invalidates nothing.
+ */
+export function RatingControl({
+  articleId,
+  rating,
+  className,
+}: RatingControlProps) {
+  const rate = useRateArticle();
+
+  return (
+    <ToggleGroup
+      type="single"
+      variant="outline"
+      size="sm"
+      value={ratingToValue(rating)}
+      onValueChange={(value) =>
+        rate.mutate({ id: articleId, value: valueToRating(value) })
+      }
+      className={className}
+    >
+      <ToggleGroupItem value="up" aria-label="Thumbs up">
+        <ThumbsUp />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="down" aria-label="Thumbs down">
+        <ThumbsDown />
+      </ToggleGroupItem>
+    </ToggleGroup>
+  );
+}

--- a/frontend/src/components/rating-control.tsx
+++ b/frontend/src/components/rating-control.tsx
@@ -53,6 +53,11 @@ export function RatingControl({
       type="single"
       variant="outline"
       size="sm"
+      // Gap the two thumbs so each keeps its own full border — at the default
+      // spacing=0 the segmented group collapses the shared edge (`border-l-0`
+      // on the right item), leaving a selected right thumb with no left border
+      // to draw in the primary color.
+      spacing={1}
       value={ratingToValue(rating)}
       onValueChange={(value) =>
         rate.mutate({ id: articleId, value: valueToRating(value) })

--- a/frontend/src/components/rating-control.tsx
+++ b/frontend/src/components/rating-control.tsx
@@ -64,15 +64,15 @@ export function RatingControl({
       }
       className={className}
     >
-      <ToggleGroupItem value="up" aria-label="Thumbs up" className={SELECTED}>
-        <ThumbsUp />
-      </ToggleGroupItem>
       <ToggleGroupItem
         value="down"
         aria-label="Thumbs down"
         className={SELECTED}
       >
         <ThumbsDown />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="up" aria-label="Thumbs up" className={SELECTED}>
+        <ThumbsUp />
       </ToggleGroupItem>
     </ToggleGroup>
   );

--- a/frontend/src/components/ui/toggle-group.tsx
+++ b/frontend/src/components/ui/toggle-group.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import * as React from "react";
+import { type VariantProps } from "class-variance-authority";
+import { ToggleGroup as ToggleGroupPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+import { toggleVariants } from "@/components/ui/toggle";
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number;
+  }
+>({
+  size: "default",
+  variant: "default",
+  spacing: 0,
+});
+
+function ToggleGroup({
+  className,
+  variant,
+  size,
+  spacing = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Root> &
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number;
+  }) {
+  return (
+    <ToggleGroupPrimitive.Root
+      data-slot="toggle-group"
+      data-variant={variant}
+      data-size={size}
+      data-spacing={spacing}
+      style={{ "--gap": spacing } as React.CSSProperties}
+      className={cn(
+        "group/toggle-group flex w-fit items-center gap-[--spacing(var(--gap))] rounded-md data-[spacing=default]:data-[variant=outline]:shadow-xs",
+        className,
+      )}
+      {...props}
+    >
+      <ToggleGroupContext.Provider value={{ variant, size, spacing }}>
+        {children}
+      </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive.Root>
+  );
+}
+
+function ToggleGroupItem({
+  className,
+  children,
+  variant,
+  size,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Item> &
+  VariantProps<typeof toggleVariants>) {
+  const context = React.useContext(ToggleGroupContext);
+
+  return (
+    <ToggleGroupPrimitive.Item
+      data-slot="toggle-group-item"
+      data-variant={context.variant || variant}
+      data-size={context.size || size}
+      data-spacing={context.spacing}
+      className={cn(
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        "w-auto min-w-0 shrink-0 px-3 focus:z-10 focus-visible:z-10",
+        "data-[spacing=0]:rounded-none data-[spacing=0]:shadow-none data-[spacing=0]:first:rounded-l-md data-[spacing=0]:last:rounded-r-md data-[spacing=0]:data-[variant=outline]:border-l-0 data-[spacing=0]:data-[variant=outline]:first:border-l",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </ToggleGroupPrimitive.Item>
+  );
+}
+
+export { ToggleGroup, ToggleGroupItem };

--- a/frontend/src/components/ui/toggle.tsx
+++ b/frontend/src/components/ui/toggle.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { Toggle as TogglePrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+const toggleVariants = cva(
+  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-[color,box-shadow] outline-none hover:bg-muted hover:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline:
+          "border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground",
+      },
+      size: {
+        default: "h-9 min-w-9 px-2",
+        sm: "h-8 min-w-8 px-1.5",
+        lg: "h-10 min-w-10 px-2.5",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+function Toggle({
+  className,
+  variant,
+  size,
+  ...props
+}: React.ComponentProps<typeof TogglePrimitive.Root> &
+  VariantProps<typeof toggleVariants>) {
+  return (
+    <TogglePrimitive.Root
+      data-slot="toggle"
+      className={cn(toggleVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Toggle, toggleVariants };

--- a/frontend/src/hooks/useRateArticle.ts
+++ b/frontend/src/hooks/useRateArticle.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import {
+  useMutation,
+  useQueryClient,
+  type InfiniteData,
+} from "@tanstack/react-query";
+import { rateArticle } from "@/lib/api";
+import { queryKeys } from "@/lib/queryKeys";
+import type { Article, ArticleListResponse } from "@/lib/types";
+
+export function useRateArticle() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, value }: { id: number; value: 1 | -1 | null }) =>
+      rateArticle(id, value),
+    onSuccess: (updated, { id }) => {
+      // Rating is inert in v2 — it changes no counts, ordering, or filtering.
+      // Surgically patch the rating into every cached list page and the detail
+      // cache; deliberately do NOT invalidate feeds/folders/counts.
+      queryClient.setQueriesData<InfiniteData<ArticleListResponse>>(
+        { queryKey: queryKeys.articles.all },
+        (data) => {
+          if (!data || !("pages" in data)) return data;
+          return {
+            ...data,
+            pages: data.pages.map((page) => ({
+              ...page,
+              items: page.items.map((item) =>
+                item.id === id ? { ...item, rating: updated.rating } : item,
+              ),
+            })),
+          };
+        },
+      );
+
+      queryClient.setQueryData<Article>(
+        queryKeys.articles.detail(id),
+        (existing) =>
+          existing ? { ...existing, rating: updated.rating } : existing,
+      );
+    },
+    meta: { errorTitle: "Failed to rate article" },
+  });
+}

--- a/frontend/src/hooks/useUpdatePreferences.ts
+++ b/frontend/src/hooks/useUpdatePreferences.ts
@@ -10,14 +10,21 @@ export function useUpdatePreferences() {
 
   return useMutation({
     mutationFn: (update: PreferencesUpdate) => updatePreferences(update),
-    onSuccess: (data) => {
+    onSuccess: (data, variables) => {
       // Write the authoritative PUT response straight to cache so the interests
       // form's remount-reset (keyed on updated_at) is deterministic and doesn't
-      // hinge on a follow-up refetch that could fail. Interests/anti-interests
-      // changes trigger a server-side rescore, so wake the scoring chip too.
+      // hinge on a follow-up refetch that could fail.
       queryClient.setQueryData(queryKeys.preferences.detail, data);
-      queryClient.invalidateQueries({ queryKey: queryKeys.scoring.status });
+      // Only interests/anti-interests changes trigger a server-side rescore, so
+      // wake the scoring chip only for those — a dwell-only save leaves scoring
+      // untouched and shouldn't refetch it.
+      if (
+        variables.interests !== undefined ||
+        variables.anti_interests !== undefined
+      ) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.scoring.status });
+      }
     },
-    meta: { errorTitle: "Couldn't save your interests" },
+    meta: { errorTitle: "Couldn't save your preferences" },
   });
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -244,6 +244,23 @@ export async function updateArticleRead(
   return response.json();
 }
 
+export async function rateArticle(
+  id: number,
+  value: 1 | -1 | null,
+): Promise<Article> {
+  const response = await fetch(`/api/articles/${id}/rating`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ value }),
+  });
+
+  if (!response.ok) {
+    await throwApiError(response, "Failed to rate article");
+  }
+
+  return response.json();
+}
+
 export async function fetchArticleCounts(): Promise<ArticleCounts> {
   const response = await fetch("/api/articles/counts");
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -89,6 +89,8 @@ export interface ArticleListItem {
   scoring_state: string;
   scored_at: string | null;
   re_evaluating: boolean;
+  /** Thumbs rating projection: `1` (up), `-1` (down), or `null` (never rated / cleared). */
+  rating: number | null;
 }
 
 /** Mirrors backend response for `GET /api/articles`. */
@@ -114,6 +116,8 @@ export interface Article {
   scoring_state: string;
   scored_at: string | null;
   re_evaluating: boolean;
+  /** Thumbs rating projection: `1` (up), `-1` (down), or `null` (never rated / cleared). */
+  rating: number | null;
   summary: string | null;
   /** Raw HTML. */
   content: string | null;
@@ -244,6 +248,8 @@ export interface Preferences {
   interests: string;
   anti_interests: string;
   feed_refresh_interval: number;
+  /** Seconds an opened article must be dwelled on before it auto-marks read (1–60). */
+  mark_read_dwell_seconds: number;
   updated_at: string;
 }
 
@@ -252,6 +258,7 @@ export interface PreferencesUpdate {
   interests?: string;
   anti_interests?: string;
   feed_refresh_interval?: number;
+  mark_read_dwell_seconds?: number;
 }
 
 /** Mirrors backend `GET /api/scoring/status` response. Only the top-level scoring_state counts and `phase` are typed precisely — we read those now. Everything else is loosely typed. */

--- a/frontend/src/test/mocks/handlers/articles.ts
+++ b/frontend/src/test/mocks/handlers/articles.ts
@@ -29,6 +29,7 @@ export const mockArticles: ArticleListItem[] = Array.from(
       scoring_state: "scored",
       scored_at: null,
       re_evaluating: false,
+      rating: null,
     };
   },
 );
@@ -50,6 +51,7 @@ export const mockArticleDetail: Article = {
   scoring_state: "scored",
   scored_at: null,
   re_evaluating: false,
+  rating: null,
   summary: "Full summary of article 1",
   content: "<p>Full article content</p>",
 };
@@ -95,6 +97,7 @@ export const mockBlockedArticles: ArticleListItem[] = [
     scoring_state: "blocked",
     scored_at: null,
     re_evaluating: false,
+    rating: null,
   },
   {
     id: 9002,
@@ -131,6 +134,7 @@ export const mockBlockedArticles: ArticleListItem[] = [
     scoring_state: "blocked",
     scored_at: null,
     re_evaluating: false,
+    rating: null,
   },
   {
     id: 9003,
@@ -159,6 +163,7 @@ export const mockBlockedArticles: ArticleListItem[] = [
     scoring_state: "blocked",
     scored_at: null,
     re_evaluating: false,
+    rating: null,
   },
 ];
 
@@ -238,6 +243,16 @@ export const articleHandlers = [
       ...mockArticleDetail,
       id,
       is_read: body.is_read,
+    });
+  }),
+
+  http.put("/api/articles/:id/rating", async ({ params, request }) => {
+    const id = Number(params.id);
+    const body = (await request.json()) as { value: 1 | -1 | null };
+    return HttpResponse.json({
+      ...mockArticleDetail,
+      id,
+      rating: body.value,
     });
   }),
 ];

--- a/frontend/src/test/mocks/handlers/preferences.ts
+++ b/frontend/src/test/mocks/handlers/preferences.ts
@@ -6,6 +6,7 @@ export const mockPreferences: Preferences = {
   interests: "AI, distributed systems",
   anti_interests: "celebrity gossip",
   feed_refresh_interval: 1800,
+  mark_read_dwell_seconds: 5,
   updated_at: "2026-01-01T00:00:00",
 };
 


### PR DESCRIPTION
# Feedback capture — mutable rating + append-only event log

## What is this PR about?

Adds feedback capture (#101): a thumbs up/down/none rating on articles, ratable from both the list and the reader, plus an append-only log of feedback events (`rated`, `marked_read`, `rescued`) that will fuel a future learning layer. Also makes the reader's mark-as-read dwell configurable.

## Why is this change needed?

v2 scoring can't improve because nothing about reading behavior is recorded. This captures the raw signal now (facts only — no dwell/scroll/interpretation) so the v2.1 learning layer has real data to calibrate against.

## How is this change implemented?

- Rating: `PUT /api/articles/{id}/rating` sets/changes/clears a rating; a genuine change appends a `rated` event (NULL value on clear), same-value writes are no-ops. Rating is inert (affects no scoring/counts).
- Events emit only on genuine transitions: `marked_read` on unread→read (not bulk/un-read), `rescued` on the block→visible edge. Append-only is enforced app-layer (no update/delete route).
- Frontend: a thumbs `ToggleGroup` control shared by the list and reader (hidden in the list while the reader is open), with the selected thumb highlighted in the primary color.
- Configurable mark-as-read dwell (`mark_read_dwell_seconds`, 1–60s) in General settings, replacing the hardcoded 3s.
- Design + deliberate deferrals recorded in `docs/adr/0013`; the deferred items (impressions/exposure bias, `opened`, etc.) are tracked in #120.

## How to test this change?

1. Open an article; give it a thumbs up, then down, then tap the active thumb to clear it — the highlight follows each change.
2. Do the same from a list row; confirm tapping a thumb rates without opening the article, and that the thumbs disappear from the list while the reader is open.
3. In Settings → General, change the mark-as-read delay; open an unread article and confirm it marks read after the new delay.
4. Rescue a blocked article from the blocked view (it reappears in the normal list).

## Notes

- Reviewer focus: event-emission edges (no-op rating, un-read, mark-all-read, rescue replay) are covered by API-seam tests; the rating control by MSW tests.
- Deliberate scope call: `opened` was deferred (three event types, not four) — see the resolution comment on #101 and ADR-0013.
- Migration `b60d6250cb10` adds only `mark_read_dwell_seconds` (the rating/event schema already ships in the v2 baseline).
- Optional follow-ups noted in review (not done, they touch pre-existing code): a shared `patchArticleInCaches` frontend helper and a backend `_get_article_or_404` loader.
