### PR TITLE
fix(#107): remove dev CORS middleware now that v2 is same-origin

### DIFF
--- a/backend/src/backend/main.py
+++ b/backend/src/backend/main.py
@@ -5,7 +5,6 @@ import os
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
 
 from backend.config import get_settings
 from backend.database import create_db_and_tables
@@ -66,14 +65,6 @@ app = FastAPI(
     title="RSS Reader API",
     version="0.1.0",
     lifespan=lifespan,
-)
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["http://localhost:3210", "http://localhost:3000"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
 )
 
 # Register routers


### PR DESCRIPTION
# Remove dev CORS middleware (v2 is same-origin)

## What is this PR about?

Removes the backend's CORS middleware, which allowed the browser to make cross-origin requests from the old v1 dev frontend ports. It's no longer needed.

## Why is this change needed?

The v2 frontend is same-origin with the backend in every environment — dev routes `/api` through the Next rewrites proxy (#92), and prod routes it through the reverse proxy. So the browser never makes a cross-origin call, and the allow-list of localhost dev ports is dead configuration. Leaving a stale permission grant around is worse than removing it.

## How is this change implemented?

- Remove the `CORSMiddleware` registration from `backend/src/backend/main.py`.
- Remove the now-unused `from fastapi.middleware.cors import CORSMiddleware` import.
- No other code, config, or test in the repo referenced CORS (verified).

## How to test this change?

1. Start the backend and frontend dev servers as usual.
2. Open the app in the browser and load your feeds and articles.
3. Confirm everything works exactly as before — articles load, read/unread toggles, feeds refresh.

## Notes

- Reviewer focus: the only out-of-repo risk is a browser-based client that hits the backend directly cross-origin. For a single-user self-hosted app behind a reverse proxy, none should exist.
- Backend gate all green locally: `ruff`, `ruff format --check`, `pyright` (0 errors), `pytest` (303 passed).

Closes #107. Refs #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)