### PR TITLE
docs(#102): README v2 deploy corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,6 @@ A personal RSS reader with LLM-powered content curation. Surfaces interesting ar
 
 ![Topic categories](docs/settings-categories.png)
 
-**LLM Providers** — Configure model provider, select models for categorization and scoring, and view system prompts.
-
-![LLM Providers](docs/settings-llm-providers.png)
-
 ---
 
 ## Quick Start
@@ -46,6 +42,8 @@ A personal RSS reader with LLM-powered content curation. Surfaces interesting ar
 - An [Azure AI Foundry](https://azure.microsoft.com/en-us/products/ai-foundry) endpoint and API key
 
 ### Deploy
+
+> **⚠ Upgrading from v1:** v2 uses a fresh database schema with no migration path from v1 (ADR-0003). Start from an **empty** data volume — reusing a v1 SQLite database will fail at startup because its recorded migration revision isn't in the v2 chain. Re-adding your feeds is expected one-time work.
 
 Create a `docker-compose.yml` adapted to your setup:
 
@@ -128,6 +126,20 @@ logging:
 
 scheduler:
   log_job_execution: false
+
+# Per-task Azure deployment routing (ADR-0002). The deployment names must
+# match the deployments you created in your Azure AI Foundry resource;
+# the endpoint and API key come from env vars, not this file.
+llm:
+  tasks:
+    scoring:
+      deployment: <your-scoring-deployment>
+      batch_size: 5
+    categorization:
+      deployment: <your-categorization-deployment>
+      batch_size: 10
+    grouping:
+      deployment: <your-grouping-deployment>
 ```
 
 ### Environment Variables
@@ -141,7 +153,7 @@ Environment variables use double-underscore notation for nested config:
 | `AZURE_OPENAI_API_KEY` | Azure AI Foundry API key | *(none)* |
 | `CONFIG_FILE` | Path to YAML config file | *(none)* |
 
-> **Note:** Model selection and feed refresh interval are configured through the Settings UI and stored in the database.
+> **Note:** Per-task model routing is set in the YAML config file under `llm.tasks` (see above) — there is no model-selection UI. The feed refresh interval is stored in the database and adjustable through preferences.
 
 ---
 


### PR DESCRIPTION
# README v2 deploy corrections

## What is this PR about?

Corrects the README so the operator-facing deploy docs match the v2 architecture, closing the AC #3 gap on release issue #102.

## Why is this change needed?

The README still described v1 behavior. Following it would produce a deploy that boots healthy but silently does nothing — model routing wasn't documented, and a deleted settings screen was still referenced.

## How is this change implemented?

- Removed the stale "LLM Providers" settings screenshot (that UI was deleted in v2).
- Added the `llm.tasks` Azure deployment-routing block to the config example (defaults to empty in code, so it's required for scoring/categorization to run).
- Added a fresh-database upgrade warning — v2 has no migration path from v1 (ADR-0003).
- Fixed the model-selection note: routing is config-file-based, not a Settings UI.

## How to test this change?

1. Open the README and read the **Deploy** and **Configuration** sections.
2. Confirm the `llm.tasks` block appears in the config example and the upgrade warning is present.
3. Confirm there's no longer an "LLM Providers" settings screenshot.

## Notes

- Part of the #102 release checklist; must land on `v2` before the `v2 → main` release merge so the published docs are correct.
- Docs-only change; no code paths touched.